### PR TITLE
Null 프로필 처리 로직 적용

### DIFF
--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -403,7 +403,7 @@ class _PostViewPageState extends State<PostViewPage> {
       child: Row(
         children: [
           // 사용자 프로필 사진.
-          // 프로필 이미지 링크가 null일 경우 회색 바탕으로 표시함.
+          // 프로필 이미지 링크가 null일 경우 warning 아이콘 표시
           Container(
             width: 30,
             height: 30,

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -850,8 +850,8 @@ class _PostViewPageState extends State<PostViewPage> {
                             ? null
                             : () {
                                 Navigator.of(context).push(slideRoute(
-                                  UserViewPage(userID: curComment.created_by.id)
-                                ));
+                                    UserViewPage(
+                                        userID: curComment.created_by.id)));
                               },
                         child: Row(
                           children: [

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -415,27 +415,39 @@ class _PostViewPageState extends State<PostViewPage> {
               borderRadius: const BorderRadius.all(Radius.circular(100)),
               child: SizedBox.fromSize(
                 size: const Size.fromRadius(15),
-                child: Image.network(
-                  fit: BoxFit.cover,
-                  _article.created_by.profile.picture ?? "null",
-                  // 정상적인 이미지 로드에 실패했을 경우
-                  // warning 아이콘 표시하기
-                  errorBuilder: (BuildContext context, Object error,
-                      StackTrace? stackTrace) {
-                    debugPrint("$error");
-                    return SizedBox(
-                      child: SvgPicture.asset(
-                        "assets/icons/warning.svg",
-                        colorFilter: const ColorFilter.mode(
-                          Colors.black,
-                          BlendMode.srcIn,
+                child: _article.created_by.profile.picture == null
+                    ? SizedBox(
+                        child: SvgPicture.asset(
+                          "assets/icons/warning.svg",
+                          colorFilter: const ColorFilter.mode(
+                            Colors.black,
+                            BlendMode.srcIn,
+                          ),
+                          width: 25,
+                          height: 25,
                         ),
-                        width: 25,
-                        height: 25,
+                      )
+                    : Image.network(
+                        fit: BoxFit.cover,
+                        _article.created_by.profile.picture.toString(),
+                        // 정상적인 이미지 로드에 실패했을 경우
+                        // warning 아이콘 표시하기
+                        errorBuilder: (BuildContext context, Object error,
+                            StackTrace? stackTrace) {
+                          debugPrint("PostViewPage creator: $error");
+                          return SizedBox(
+                            child: SvgPicture.asset(
+                              "assets/icons/warning.svg",
+                              colorFilter: const ColorFilter.mode(
+                                Colors.black,
+                                BlendMode.srcIn,
+                              ),
+                              width: 25,
+                              height: 25,
+                            ),
+                          );
+                        },
                       ),
-                    );
-                  },
-                ),
               ),
             ),
           ),
@@ -869,28 +881,45 @@ class _PostViewPageState extends State<PostViewPage> {
                                     Radius.circular(100)),
                                 child: SizedBox.fromSize(
                                   size: const Size.fromRadius(12.5),
-                                  child: Image.network(
-                                    fit: BoxFit.cover,
-                                    curComment.created_by.profile.picture ??
-                                        "null",
-                                    // 정상적인 이미지 로드에 실패했을 경우
-                                    // warning 아이콘 표시하기
-                                    errorBuilder: (BuildContext context,
-                                        Object error, StackTrace? stackTrace) {
-                                      debugPrint("$error");
-                                      return SizedBox(
-                                        child: SvgPicture.asset(
-                                          "assets/icons/warning.svg",
-                                          colorFilter: const ColorFilter.mode(
-                                            Colors.black,
-                                            BlendMode.srcIn,
+                                  child: curComment
+                                              .created_by.profile.picture ==
+                                          null
+                                      ? SizedBox(
+                                          child: SvgPicture.asset(
+                                            "assets/icons/warning.svg",
+                                            colorFilter: const ColorFilter.mode(
+                                              Colors.black,
+                                              BlendMode.srcIn,
+                                            ),
+                                            width: 20,
+                                            height: 20,
                                           ),
-                                          width: 20,
-                                          height: 20,
+                                        )
+                                      : Image.network(
+                                          fit: BoxFit.cover,
+                                          curComment
+                                                  .created_by.profile.picture ??
+                                              "null",
+                                          // 정상적인 이미지 로드에 실패했을 경우
+                                          // warning 아이콘 표시하기
+                                          errorBuilder: (BuildContext context,
+                                              Object error,
+                                              StackTrace? stackTrace) {
+                                            debugPrint("PostViewPage Comment: $error");
+                                            return SizedBox(
+                                              child: SvgPicture.asset(
+                                                "assets/icons/warning.svg",
+                                                colorFilter:
+                                                    const ColorFilter.mode(
+                                                  Colors.black,
+                                                  BlendMode.srcIn,
+                                                ),
+                                                width: 20,
+                                                height: 20,
+                                              ),
+                                            );
+                                          },
                                         ),
-                                      );
-                                    },
-                                  ),
                                 ),
                               ),
                             ),

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -403,6 +403,7 @@ class _PostViewPageState extends State<PostViewPage> {
       child: Row(
         children: [
           // 사용자 프로필 사진.
+          // 프로필 이미지 링크가 null일 경우 회색 바탕으로 표시함.
           Container(
             width: 30,
             height: 30,
@@ -410,15 +411,17 @@ class _PostViewPageState extends State<PostViewPage> {
               shape: BoxShape.circle,
               color: Colors.grey,
             ),
-            child: ClipRRect(
-              borderRadius: const BorderRadius.all(Radius.circular(100)),
-              child: SizedBox.fromSize(
-                size: const Size.fromRadius(48),
-                child: Image.network(
-                    fit: BoxFit.cover,
-                    _article.created_by.profile.picture.toString()),
-              ),
-            ),
+            child: _article.created_by.profile.picture == null
+                ? Container()
+                : ClipRRect(
+                    borderRadius: const BorderRadius.all(Radius.circular(100)),
+                    child: SizedBox.fromSize(
+                      size: const Size.fromRadius(30),
+                      child: Image.network(
+                          fit: BoxFit.cover,
+                          _article.created_by.profile.picture!),
+                    ),
+                  ),
           ),
           const SizedBox(width: 10),
           // 사용자 닉네임 텍스트 표시.
@@ -846,21 +849,20 @@ class _PostViewPageState extends State<PostViewPage> {
                                 shape: BoxShape.circle,
                                 color: Colors.grey,
                               ),
-                              child: ClipRRect(
-                                borderRadius: const BorderRadius.all(
-                                    Radius.circular(100)),
-                                child: ClipRRect(
-                                  borderRadius: const BorderRadius.all(
-                                      Radius.circular(100)),
-                                  child: SizedBox.fromSize(
-                                    size: const Size.fromRadius(48),
-                                    child: Image.network(
-                                        fit: BoxFit.cover,
-                                        curComment.created_by.profile.picture
-                                            .toString()),
-                                  ),
-                                ),
-                              ),
+                              child:
+                                  curComment.created_by.profile.picture == null
+                                      ? Container()
+                                      : ClipRRect(
+                                          borderRadius: const BorderRadius.all(
+                                              Radius.circular(100)),
+                                          child: SizedBox.fromSize(
+                                            size: const Size.fromRadius(25),
+                                            child: Image.network(
+                                                fit: BoxFit.cover,
+                                                curComment.created_by.profile
+                                                    .picture!),
+                                          ),
+                                        ),
                             ),
                             const SizedBox(width: 5),
                             Container(

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -21,7 +21,7 @@ import 'package:new_ara_app/utils/slide_routing.dart';
 import 'package:new_ara_app/widgets/in_article_web_view.dart';
 import 'package:new_ara_app/providers/notification_provider.dart';
 import 'package:new_ara_app/widgets/pop_up_menu_buttons.dart';
-import 'package:webview_flutter/webview_flutter.dart';
+import 'package:new_ara_app/utils/profile_image.dart';
 
 /// 하나의 post에 대한 내용 뷰, 이벤트 처리를 모두 담당하는 StatefulWidget.
 class PostViewPage extends StatefulWidget {
@@ -390,6 +390,9 @@ class _PostViewPageState extends State<PostViewPage> {
   /// 작성자 정보 빌드를 담당하며 빌드된 위젯을 리턴.
   /// _article 클래스 전역변수를 사용함.
   Widget _buildAuthorInfo(UserProvider userProvider) {
+    debugPrint("**********************************************");
+    debugPrint("BUILDAUTHORINFO INVOKED");
+    debugPrint("**********************************************");
     return InkWell(
       // 익명일 경우 작성자 정보확인이 불가하도록 함.
       onTap: _article.name_type == 2
@@ -397,6 +400,9 @@ class _PostViewPageState extends State<PostViewPage> {
           : () async {
               await Navigator.of(context).push(
                   slideRoute(UserViewPage(userID: _article.created_by.id)));
+              debugPrint("**********************************************");
+              debugPrint("RETURN TO POSTVIEWPAGE");
+              debugPrint("**********************************************");
               // 유저 정보 페이지에서 돌아올 때 페이지를 업데이트함.
               _setIsPageLoaded(await _fetchArticle(userProvider));
             },
@@ -415,39 +421,10 @@ class _PostViewPageState extends State<PostViewPage> {
               borderRadius: const BorderRadius.all(Radius.circular(100)),
               child: SizedBox.fromSize(
                 size: const Size.fromRadius(15),
-                child: _article.created_by.profile.picture == null
-                    ? SizedBox(
-                        child: SvgPicture.asset(
-                          "assets/icons/warning.svg",
-                          colorFilter: const ColorFilter.mode(
-                            Colors.black,
-                            BlendMode.srcIn,
-                          ),
-                          width: 25,
-                          height: 25,
-                        ),
-                      )
-                    : Image.network(
-                        fit: BoxFit.cover,
-                        _article.created_by.profile.picture.toString(),
-                        // 정상적인 이미지 로드에 실패했을 경우
-                        // warning 아이콘 표시하기
-                        errorBuilder: (BuildContext context, Object error,
-                            StackTrace? stackTrace) {
-                          debugPrint("PostViewPage creator: $error");
-                          return SizedBox(
-                            child: SvgPicture.asset(
-                              "assets/icons/warning.svg",
-                              colorFilter: const ColorFilter.mode(
-                                Colors.black,
-                                BlendMode.srcIn,
-                              ),
-                              width: 25,
-                              height: 25,
-                            ),
-                          );
-                        },
-                      ),
+                // 이미지 프로필이 null인 경우 network 호출하지 않고
+                // warning 아이콘 빌드
+                child: buildProfileImage(
+                    _article.created_by.profile.picture, 25, 25),
               ),
             ),
           ),
@@ -881,45 +858,12 @@ class _PostViewPageState extends State<PostViewPage> {
                                     Radius.circular(100)),
                                 child: SizedBox.fromSize(
                                   size: const Size.fromRadius(12.5),
-                                  child: curComment
-                                              .created_by.profile.picture ==
-                                          null
-                                      ? SizedBox(
-                                          child: SvgPicture.asset(
-                                            "assets/icons/warning.svg",
-                                            colorFilter: const ColorFilter.mode(
-                                              Colors.black,
-                                              BlendMode.srcIn,
-                                            ),
-                                            width: 20,
-                                            height: 20,
-                                          ),
-                                        )
-                                      : Image.network(
-                                          fit: BoxFit.cover,
-                                          curComment
-                                                  .created_by.profile.picture ??
-                                              "null",
-                                          // 정상적인 이미지 로드에 실패했을 경우
-                                          // warning 아이콘 표시하기
-                                          errorBuilder: (BuildContext context,
-                                              Object error,
-                                              StackTrace? stackTrace) {
-                                            debugPrint("PostViewPage Comment: $error");
-                                            return SizedBox(
-                                              child: SvgPicture.asset(
-                                                "assets/icons/warning.svg",
-                                                colorFilter:
-                                                    const ColorFilter.mode(
-                                                  Colors.black,
-                                                  BlendMode.srcIn,
-                                                ),
-                                                width: 20,
-                                                height: 20,
-                                              ),
-                                            );
-                                          },
-                                        ),
+                                  // 이미지 프로필이 null인 경우
+                                  // network를 호출하지 않고
+                                  child: buildProfileImage(
+                                      curComment.created_by.profile.picture,
+                                      20,
+                                      20),
                                 ),
                               ),
                             ),

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -849,12 +849,9 @@ class _PostViewPageState extends State<PostViewPage> {
                         onTap: curComment.name_type == 2
                             ? null
                             : () {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                      builder: (context) => UserViewPage(
-                                          userID: curComment.created_by.id)),
-                                );
+                                Navigator.of(context).push(slideRoute(
+                                  UserViewPage(userID: curComment.created_by.id)
+                                ));
                               },
                         child: Row(
                           children: [

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -421,8 +421,7 @@ class _PostViewPageState extends State<PostViewPage> {
               borderRadius: const BorderRadius.all(Radius.circular(100)),
               child: SizedBox.fromSize(
                 size: const Size.fromRadius(15),
-                // 이미지 프로필이 null인 경우 network 호출하지 않고
-                // warning 아이콘 빌드
+                // 이미지 링크를 확인한 후 null인 이미지는 warning.svg를 빌드
                 child: buildProfileImage(
                     _article.created_by.profile.picture, 25, 25),
               ),
@@ -858,8 +857,7 @@ class _PostViewPageState extends State<PostViewPage> {
                                     Radius.circular(100)),
                                 child: SizedBox.fromSize(
                                   size: const Size.fromRadius(12.5),
-                                  // 이미지 프로필이 null인 경우
-                                  // network를 호출하지 않고
+                                  // 이미지 링크를 확인한 후 null인 이미지는 warning.svg를 빌드
                                   child: buildProfileImage(
                                       curComment.created_by.profile.picture,
                                       20,

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -414,7 +414,7 @@ class _PostViewPageState extends State<PostViewPage> {
             child: ClipRRect(
               borderRadius: const BorderRadius.all(Radius.circular(100)),
               child: SizedBox.fromSize(
-                size: const Size.fromRadius(30),
+                size: const Size.fromRadius(15),
                 child: Image.network(
                   fit: BoxFit.cover,
                   _article.created_by.profile.picture ?? "null",
@@ -871,7 +871,7 @@ class _PostViewPageState extends State<PostViewPage> {
                                 borderRadius: const BorderRadius.all(
                                     Radius.circular(100)),
                                 child: SizedBox.fromSize(
-                                  size: const Size.fromRadius(25),
+                                  size: const Size.fromRadius(12.5),
                                   child: Image.network(
                                     fit: BoxFit.cover,
                                     curComment.created_by.profile.picture ??

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -842,6 +842,8 @@ class _PostViewPageState extends State<PostViewPage> {
                               },
                         child: Row(
                           children: [
+                            // 댓글 작성자 프로필 이미지 표시
+                            // 이미지 링크가 null일 경우 회색 바탕으로 표시.
                             Container(
                               width: 25,
                               height: 25,

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -427,7 +427,8 @@ class _PostViewPageState extends State<PostViewPage> {
                       child: SvgPicture.asset(
                         "assets/icons/warning.svg",
                         colorFilter: const ColorFilter.mode(
-                          Colors.black, BlendMode.srcIn,
+                          Colors.black,
+                          BlendMode.srcIn,
                         ),
                         width: 25,
                         height: 25,
@@ -858,7 +859,7 @@ class _PostViewPageState extends State<PostViewPage> {
                         child: Row(
                           children: [
                             // 댓글 작성자 프로필 이미지 표시
-                            // 이미지 링크가 null일 경우 회색 바탕으로 표시.
+                            // 이미지 링크가 null일 경우 warning 아이콘 표시
                             Container(
                               width: 25,
                               height: 25,
@@ -866,20 +867,35 @@ class _PostViewPageState extends State<PostViewPage> {
                                 shape: BoxShape.circle,
                                 color: Colors.grey,
                               ),
-                              child:
-                                  curComment.created_by.profile.picture == null
-                                      ? Container()
-                                      : ClipRRect(
-                                          borderRadius: const BorderRadius.all(
-                                              Radius.circular(100)),
-                                          child: SizedBox.fromSize(
-                                            size: const Size.fromRadius(25),
-                                            child: Image.network(
-                                                fit: BoxFit.cover,
-                                                curComment.created_by.profile
-                                                    .picture!),
+                              child: ClipRRect(
+                                borderRadius: const BorderRadius.all(
+                                    Radius.circular(100)),
+                                child: SizedBox.fromSize(
+                                  size: const Size.fromRadius(25),
+                                  child: Image.network(
+                                    fit: BoxFit.cover,
+                                    curComment.created_by.profile.picture ??
+                                        "null",
+                                    // 정상적인 이미지 로드에 실패했을 경우
+                                    // warning 아이콘 표시하기
+                                    errorBuilder: (BuildContext context,
+                                        Object error, StackTrace? stackTrace) {
+                                      debugPrint("$error");
+                                      return SizedBox(
+                                        child: SvgPicture.asset(
+                                          "assets/icons/warning.svg",
+                                          colorFilter: const ColorFilter.mode(
+                                            Colors.black,
+                                            BlendMode.srcIn,
                                           ),
+                                          width: 20,
+                                          height: 20,
                                         ),
+                                      );
+                                    },
+                                  ),
+                                ),
+                              ),
                             ),
                             const SizedBox(width: 5),
                             Container(

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -411,17 +411,32 @@ class _PostViewPageState extends State<PostViewPage> {
               shape: BoxShape.circle,
               color: Colors.grey,
             ),
-            child: _article.created_by.profile.picture == null
-                ? Container()
-                : ClipRRect(
-                    borderRadius: const BorderRadius.all(Radius.circular(100)),
-                    child: SizedBox.fromSize(
-                      size: const Size.fromRadius(30),
-                      child: Image.network(
-                          fit: BoxFit.cover,
-                          _article.created_by.profile.picture!),
-                    ),
-                  ),
+            child: ClipRRect(
+              borderRadius: const BorderRadius.all(Radius.circular(100)),
+              child: SizedBox.fromSize(
+                size: const Size.fromRadius(30),
+                child: Image.network(
+                  fit: BoxFit.cover,
+                  _article.created_by.profile.picture ?? "null",
+                  // 정상적인 이미지 로드에 실패했을 경우
+                  // warning 아이콘 표시하기
+                  errorBuilder: (BuildContext context, Object error,
+                      StackTrace? stackTrace) {
+                    debugPrint("$error");
+                    return SizedBox(
+                      child: SvgPicture.asset(
+                        "assets/icons/warning.svg",
+                        colorFilter: const ColorFilter.mode(
+                          Colors.black, BlendMode.srcIn,
+                        ),
+                        width: 25,
+                        height: 25,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
           ),
           const SizedBox(width: 10),
           // 사용자 닉네임 텍스트 표시.

--- a/lib/pages/profile_edit_page.dart
+++ b/lib/pages/profile_edit_page.dart
@@ -312,6 +312,7 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
                       child: Text('This image type is not supported'));
                 },
               )
+            // 이미지 링크를 확인한 후 null인 이미지는 warning.svg를 빌드
             : buildProfileImage(userProviderData.naUser!.picture,
                 profileDiameter - 5, profileDiameter - 5));
   }

--- a/lib/pages/profile_edit_page.dart
+++ b/lib/pages/profile_edit_page.dart
@@ -13,6 +13,7 @@ import 'package:new_ara_app/constants/colors_info.dart';
 import 'package:new_ara_app/models/user_profile_model.dart';
 import 'package:new_ara_app/widgets/loading_indicator.dart';
 import 'package:new_ara_app/providers/notification_provider.dart';
+import 'package:new_ara_app/utils/profile_image.dart';
 
 class ProfileEditPage extends StatefulWidget {
   const ProfileEditPage({super.key});
@@ -188,7 +189,8 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
                               width: profileDiameter,
                               height: profileDiameter,
                               child: !(Platform.isAndroid)
-                                  ? _buildClippedImage(userProviderData, profileDiameter)
+                                  ? _buildClippedImage(
+                                      userProviderData, profileDiameter)
                                   : FutureBuilder<void>(
                                       future: _retrieveLostData(),
                                       builder: (context, snapshot) {
@@ -198,7 +200,8 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
                                           case ConnectionState.active:
                                           case ConnectionState.done:
                                             return _buildClippedImage(
-                                                userProviderData, profileDiameter);
+                                                userProviderData,
+                                                profileDiameter);
                                         }
                                       }),
                             ),
@@ -296,37 +299,21 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
   }
 
   /// 선택된 이미지 또는 기존의 프로필 이미지 위젯을 빌드하는 함수
-  ClipOval _buildClippedImage(UserProvider userProviderData, double profileDiameter) {
+  ClipOval _buildClippedImage(
+      UserProvider userProviderData, double profileDiameter) {
     return ClipOval(
-      child: _selectedImage != null
-          ? Image.file(
-              fit: BoxFit.cover,
-              File(_selectedImage!.path),
-              errorBuilder:
-                  (BuildContext context, Object error, StackTrace? stackTrace) {
-                return const Center(
-                    child: Text('This image type is not supported'));
-              },
-            )
-          : Image.network(
-              fit: BoxFit.cover,
-              userProviderData.naUser!.picture ?? "null",
-              errorBuilder:
-                  (BuildContext context, Object error, StackTrace? stackTrace) {
-                return SizedBox(
-                  child: SvgPicture.asset(
-                    "assets/icons/warning.svg",
-                    colorFilter: const ColorFilter.mode(
-                      Colors.black,
-                      BlendMode.srcIn,
-                    ),
-                    width: profileDiameter - 5,
-                    height: profileDiameter - 5,
-                  ),
-                );
-              },
-            ),
-    );
+        child: _selectedImage != null
+            ? Image.file(
+                fit: BoxFit.cover,
+                File(_selectedImage!.path),
+                errorBuilder: (BuildContext context, Object error,
+                    StackTrace? stackTrace) {
+                  return const Center(
+                      child: Text('This image type is not supported'));
+                },
+              )
+            : buildProfileImage(userProviderData.naUser!.picture,
+                profileDiameter - 5, profileDiameter - 5));
   }
 
   /// 닉네임 변경 필드를 빌드하는 함수

--- a/lib/pages/profile_edit_page.dart
+++ b/lib/pages/profile_edit_page.dart
@@ -65,7 +65,7 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
       source: ImageSource.gallery,
       maxWidth: diameter,
       maxHeight: diameter,
-      imageQuality: 100,  // (2023.08.21) default 값으로 설정함. 추후 논의 필요
+      imageQuality: 100, // (2023.08.21) default 값으로 설정함. 추후 논의 필요
     );
     if (tmpImage != null) {
       setState(() => _selectedImage = tmpImage);
@@ -119,204 +119,217 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
     MediaQueryData mediaQueryData = MediaQuery.of(context);
     double profileDiameter = mediaQueryData.size.width - 70;
 
-    return _isLoading ? const LoadingIndicator() : Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        leading: IconButton(
-          icon: SvgPicture.asset(
-            "assets/icons/close-2.svg",
-            color: ColorsInfo.newara,
-          ),
-          onPressed: () => Navigator.pop(context),
-        ),
-        title: const Text(
-          "프로필 수정",
-          style: TextStyle(
-            fontWeight: FontWeight.w700,
-            fontSize: 18,
-            color: ColorsInfo.newara,
-          ),
-        ),
-        actions: [
-          IconButton(
-            onPressed: () async {
-              _setIsLoading(true);
-              bool updateRes = await _updateProfile(userProvider);
-              debugPrint("updateRes: $updateRes");
-              _changedNick = null;
-              _selectedImage = null;
-              if (updateRes) {
-                await userProvider.apiMeUserInfo().then((getRes) {
-                  if (getRes) Navigator.pop(context);
-                });
-              } else {
-                _setIsLoading(false);
-              }
-            },
-            icon: const Text(
-              '완료',
-              style: TextStyle(
-                color: ColorsInfo.newara,
-                fontWeight: FontWeight.w500,
-                fontSize: 17,
+    return _isLoading
+        ? const LoadingIndicator()
+        : Scaffold(
+            appBar: AppBar(
+              centerTitle: true,
+              leading: IconButton(
+                icon: SvgPicture.asset(
+                  "assets/icons/close-2.svg",
+                  color: ColorsInfo.newara,
+                ),
+                onPressed: () => Navigator.pop(context),
               ),
+              title: const Text(
+                "프로필 수정",
+                style: TextStyle(
+                  fontWeight: FontWeight.w700,
+                  fontSize: 18,
+                  color: ColorsInfo.newara,
+                ),
+              ),
+              actions: [
+                IconButton(
+                  onPressed: () async {
+                    _setIsLoading(true);
+                    bool updateRes = await _updateProfile(userProvider);
+                    debugPrint("updateRes: $updateRes");
+                    _changedNick = null;
+                    _selectedImage = null;
+                    if (updateRes) {
+                      await userProvider.apiMeUserInfo().then((getRes) {
+                        if (getRes) Navigator.pop(context);
+                      });
+                    } else {
+                      _setIsLoading(false);
+                    }
+                  },
+                  icon: const Text(
+                    '완료',
+                    style: TextStyle(
+                      color: ColorsInfo.newara,
+                      fontWeight: FontWeight.w500,
+                      fontSize: 17,
+                    ),
+                  ),
+                ),
+              ],
             ),
-          ),
-        ],
-      ),
-      body: SafeArea(
-        child: GestureDetector(
-          onTap: () => FocusScope.of(context).unfocus(),
-          child: SingleChildScrollView(
-            child: SizedBox(
-              width: mediaQueryData.size.width,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const SizedBox(height: 10),
-                  Stack(
-                    children: [
-                      Container(
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          border: Border.all(
-                            color: Colors.grey,
-                          ),
-                        ),
-                        width: profileDiameter,
-                        height: profileDiameter,
-                        child: !(Platform.isAndroid) ? _buildClippedImage(userProviderData) :
-                            FutureBuilder<void>(
-                              future: _retrieveLostData(),
-                              builder: (context, snapshot) {
-                                switch (snapshot.connectionState) {
-                                  case ConnectionState.none:
-                                  case ConnectionState.waiting:
-                                  case ConnectionState.active:
-                                  case ConnectionState.done:
-                                    return _buildClippedImage(userProviderData);
-                                }
-                              }
-                            ),
-                      ),
-                      Positioned(
-                        bottom: 0,
-                        right: 50,
-                        child: AbsorbPointer(
-                          absorbing: _isCamClicked,
-                          child: InkWell(
-                            onTap: () async {
-                              if (_isCamClicked) return;
-                              setIsCamClicked(true);
-                              await _pickImage(context);
-                              setIsCamClicked(false);
-                            },  // (2023.08.19)프로필 사진 수정 기능 추후 구현 예정
-                            child: Container(
-                              width: 40,
-                              height: 40,
-                              decoration: const BoxDecoration(
+            body: SafeArea(
+              child: GestureDetector(
+                onTap: () => FocusScope.of(context).unfocus(),
+                child: SingleChildScrollView(
+                  child: SizedBox(
+                    width: mediaQueryData.size.width,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        const SizedBox(height: 10),
+                        Stack(
+                          children: [
+                            Container(
+                              decoration: BoxDecoration(
                                 shape: BoxShape.circle,
-                                color: Color.fromRGBO(51, 51, 51, 1),
+                                border: Border.all(
+                                  color: Colors.grey,
+                                ),
                               ),
-                              child: SvgPicture.asset(
-                                "assets/icons/camera.svg",
-                                color: Colors.white,
+                              width: profileDiameter,
+                              height: profileDiameter,
+                              child: !(Platform.isAndroid)
+                                  ? _buildClippedImage(userProviderData, profileDiameter)
+                                  : FutureBuilder<void>(
+                                      future: _retrieveLostData(),
+                                      builder: (context, snapshot) {
+                                        switch (snapshot.connectionState) {
+                                          case ConnectionState.none:
+                                          case ConnectionState.waiting:
+                                          case ConnectionState.active:
+                                          case ConnectionState.done:
+                                            return _buildClippedImage(
+                                                userProviderData, profileDiameter);
+                                        }
+                                      }),
+                            ),
+                            Positioned(
+                              bottom: 0,
+                              right: 50,
+                              child: AbsorbPointer(
+                                absorbing: _isCamClicked,
+                                child: InkWell(
+                                  onTap: () async {
+                                    if (_isCamClicked) return;
+                                    setIsCamClicked(true);
+                                    await _pickImage(context);
+                                    setIsCamClicked(false);
+                                  }, // (2023.08.19)프로필 사진 수정 기능 추후 구현 예정
+                                  child: Container(
+                                    width: 40,
+                                    height: 40,
+                                    decoration: const BoxDecoration(
+                                      shape: BoxShape.circle,
+                                      color: Color.fromRGBO(51, 51, 51, 1),
+                                    ),
+                                    child: SvgPicture.asset(
+                                      "assets/icons/camera.svg",
+                                      color: Colors.white,
+                                    ),
+                                  ),
+                                ),
                               ),
                             ),
+                          ],
+                        ),
+                        const SizedBox(height: 40),
+                        SizedBox(
+                          width: mediaQueryData.size.width - 60,
+                          child: Row(
+                            children: [
+                              const Text(
+                                '닉네임',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 17,
+                                  color: Color.fromRGBO(99, 99, 99, 1),
+                                ),
+                              ),
+                              const SizedBox(width: 30),
+                              Expanded(
+                                child: Container(
+                                  decoration: const BoxDecoration(
+                                    color: Color.fromRGBO(235, 235, 235, 1),
+                                    borderRadius:
+                                        BorderRadius.all(Radius.circular(10)),
+                                  ),
+                                  child: _buildForm(
+                                      userProviderData.naUser!.nickname),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 40),
-                  SizedBox(
-                    width: mediaQueryData.size.width - 60,
-                    child: Row(
-                      children: [
-                        const Text(
-                          '닉네임',
-                          style: TextStyle(
-                            fontWeight: FontWeight.w700,
-                            fontSize: 17,
-                            color: Color.fromRGBO(99, 99, 99, 1),
-                          ),
-                        ),
-                        const SizedBox(width: 30),
-                        Expanded(
-                          child: Container(
-                            decoration: const BoxDecoration(
-                              color: Color.fromRGBO(235, 235, 235, 1),
-                              borderRadius:
-                              BorderRadius.all(Radius.circular(10)),
-                            ),
-                            child: _buildForm(userProviderData.naUser!.nickname),
+                        const SizedBox(height: 30),
+                        SizedBox(
+                          width: mediaQueryData.size.width - 60,
+                          child: Row(
+                            children: [
+                              const Text(
+                                '이메일',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 17,
+                                  color: Color.fromRGBO(99, 99, 99, 1),
+                                ),
+                              ),
+                              const SizedBox(width: 45),
+                              Expanded(
+                                child: Text(
+                                  userProviderData.naUser!.email,
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w500,
+                                    fontSize: 15,
+                                    color: Color.fromRGBO(177, 177, 177, 1),
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ],
                     ),
                   ),
-                  const SizedBox(height: 30),
-                  SizedBox(
-                    width: mediaQueryData.size.width - 60,
-                    child: Row(
-                      children: [
-                        const Text(
-                          '이메일',
-                          style: TextStyle(
-                            fontWeight: FontWeight.w700,
-                            fontSize: 17,
-                            color: Color.fromRGBO(99, 99, 99, 1),
-                          ),
-                        ),
-                        const SizedBox(width: 45),
-                        Expanded(
-                          child: Text(
-                            userProviderData.naUser!.email,
-                            style: const TextStyle(
-                              fontWeight: FontWeight.w500,
-                              fontSize: 15,
-                              color: Color.fromRGBO(177, 177, 177, 1),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
-          ),
-        ),
-      ),
-    );
+          );
   }
 
-  ClipOval _buildClippedImage(UserProvider userProviderData) {
+  /// 선택된 이미지 또는 기존의 프로필 이미지 위젯을 빌드하는 함수
+  ClipOval _buildClippedImage(UserProvider userProviderData, double profileDiameter) {
     return ClipOval(
-      child: _selectedImage != null ? Image.file(
-        fit: BoxFit.cover,
-        File(_selectedImage!.path),
-        errorBuilder: (BuildContext context, Object error,
-            StackTrace? stackTrace) {
-          return const Center(
-              child:
-              Text('This image type is not supported'));
-        },
-      ) : userProviderData.naUser?.picture == null
-          ? Container()
+      child: _selectedImage != null
+          ? Image.file(
+              fit: BoxFit.cover,
+              File(_selectedImage!.path),
+              errorBuilder:
+                  (BuildContext context, Object error, StackTrace? stackTrace) {
+                return const Center(
+                    child: Text('This image type is not supported'));
+              },
+            )
           : Image.network(
-        fit: BoxFit.cover,
-        userProviderData.naUser!.picture.toString(),
-        errorBuilder: (BuildContext context, Object error,
-            StackTrace? stackTrace) {
-          return const Center(
-              child:
-              Text('Fail to load image'));
-        },
-      ),
+              fit: BoxFit.cover,
+              userProviderData.naUser!.picture ?? "null",
+              errorBuilder:
+                  (BuildContext context, Object error, StackTrace? stackTrace) {
+                return SizedBox(
+                  child: SvgPicture.asset(
+                    "assets/icons/warning.svg",
+                    colorFilter: const ColorFilter.mode(
+                      Colors.black,
+                      BlendMode.srcIn,
+                    ),
+                    width: profileDiameter - 5,
+                    height: profileDiameter - 5,
+                  ),
+                );
+              },
+            ),
     );
   }
 
+  /// 닉네임 변경 필드를 빌드하는 함수
   Form _buildForm(String initialNick) {
     return Form(
       key: _formKey,
@@ -339,7 +352,7 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
               return null;
             },
             onChanged: (value) => _changedNick = value,
-            onSaved: (value) =>  _changedNick = value ?? '',
+            onSaved: (value) => _changedNick = value ?? '',
           )),
     );
   }

--- a/lib/pages/user_page.dart
+++ b/lib/pages/user_page.dart
@@ -272,7 +272,7 @@ class _UserPageState extends State<UserPage>
             child: ClipRRect(
               borderRadius: const BorderRadius.all(Radius.circular(100)),
               child: SizedBox.fromSize(
-                size: const Size.fromRadius(50),
+                size: const Size.fromRadius(25),
                 child: Image.network(
                   fit: BoxFit.cover,
                   userProvider.naUser!.picture ?? "null",

--- a/lib/pages/user_page.dart
+++ b/lib/pages/user_page.dart
@@ -16,6 +16,7 @@ import 'package:new_ara_app/utils/time_utils.dart';
 import 'package:new_ara_app/utils/slide_routing.dart';
 import 'package:new_ara_app/pages/profile_edit_page.dart';
 import 'package:new_ara_app/providers/notification_provider.dart';
+import 'package:new_ara_app/utils/profile_image.dart';
 
 /// 작성한 글, 담아둔 글, 최근 본 글을 나타내기 위해 사용
 enum TabType { created, scrap, recent }
@@ -273,27 +274,7 @@ class _UserPageState extends State<UserPage>
               borderRadius: const BorderRadius.all(Radius.circular(100)),
               child: SizedBox.fromSize(
                 size: const Size.fromRadius(25),
-                child: Image.network(
-                  fit: BoxFit.cover,
-                  userProvider.naUser!.picture ?? "null",
-                  // 정상적인 이미지 로드에 실패했을 경우
-                  // warning 아이콘 표시하기
-                  errorBuilder: (BuildContext context, Object error,
-                      StackTrace? stackTrace) {
-                    debugPrint("$error");
-                    return SizedBox(
-                      child: SvgPicture.asset(
-                        "assets/icons/warning.svg",
-                        colorFilter: const ColorFilter.mode(
-                          Colors.black,
-                          BlendMode.srcIn,
-                        ),
-                        width: 45,
-                        height: 45,
-                      ),
-                    );
-                  },
-                ),
+                child: buildProfileImage(userProvider.naUser!.picture, 45, 45),
               ),
             ),
           ),

--- a/lib/pages/user_page.dart
+++ b/lib/pages/user_page.dart
@@ -260,23 +260,25 @@ class _UserPageState extends State<UserPage>
       height: 60,
       child: Row(
         children: [
+          // 사용자 프로필 표시
+          // 사용자 프로필 링크가 null일 경우 회색바탕으로 표시
           Container(
             width: 50,
             height: 50,
             decoration: const BoxDecoration(
               shape: BoxShape.circle,
+              color: Colors.grey,
             ),
-            child: ClipRRect(
-              borderRadius: const BorderRadius.all(Radius.circular(100)),
-              child: SizedBox.fromSize(
-                size: const Size.fromRadius(48),
-                child: userProvider.naUser?.picture == null
-                    ? Container()
-                    : Image.network(
-                        fit: BoxFit.cover,
-                        userProvider.naUser!.picture.toString()),
-              ),
-            ),
+            child: userProvider.naUser!.picture == null
+                ? Container()
+                : ClipRRect(
+                    borderRadius: const BorderRadius.all(Radius.circular(100)),
+                    child: SizedBox.fromSize(
+                      size: const Size.fromRadius(25),
+                      child: Image.network(
+                          fit: BoxFit.cover, userProvider.naUser!.picture!),
+                    ),
+                  ),
           ),
           const SizedBox(width: 10),
           Expanded(

--- a/lib/pages/user_page.dart
+++ b/lib/pages/user_page.dart
@@ -274,6 +274,7 @@ class _UserPageState extends State<UserPage>
               borderRadius: const BorderRadius.all(Radius.circular(100)),
               child: SizedBox.fromSize(
                 size: const Size.fromRadius(25),
+                // 이미지 링크를 확인한 후 null인 이미지는 warning.svg를 빌드
                 child: buildProfileImage(userProvider.naUser!.picture, 45, 45),
               ),
             ),

--- a/lib/pages/user_page.dart
+++ b/lib/pages/user_page.dart
@@ -261,7 +261,7 @@ class _UserPageState extends State<UserPage>
       child: Row(
         children: [
           // 사용자 프로필 표시
-          // 사용자 프로필 링크가 null일 경우 회색바탕으로 표시
+          // 사용자 프로필 링크가 null일 경우 warning 아이콘 표시
           Container(
             width: 50,
             height: 50,
@@ -269,16 +269,33 @@ class _UserPageState extends State<UserPage>
               shape: BoxShape.circle,
               color: Colors.grey,
             ),
-            child: userProvider.naUser!.picture == null
-                ? Container()
-                : ClipRRect(
-                    borderRadius: const BorderRadius.all(Radius.circular(100)),
-                    child: SizedBox.fromSize(
-                      size: const Size.fromRadius(25),
-                      child: Image.network(
-                          fit: BoxFit.cover, userProvider.naUser!.picture!),
-                    ),
-                  ),
+            child: ClipRRect(
+              borderRadius: const BorderRadius.all(Radius.circular(100)),
+              child: SizedBox.fromSize(
+                size: const Size.fromRadius(50),
+                child: Image.network(
+                  fit: BoxFit.cover,
+                  userProvider.naUser!.picture ?? "null",
+                  // 정상적인 이미지 로드에 실패했을 경우
+                  // warning 아이콘 표시하기
+                  errorBuilder: (BuildContext context, Object error,
+                      StackTrace? stackTrace) {
+                    debugPrint("$error");
+                    return SizedBox(
+                      child: SvgPicture.asset(
+                        "assets/icons/warning.svg",
+                        colorFilter: const ColorFilter.mode(
+                          Colors.black,
+                          BlendMode.srcIn,
+                        ),
+                        width: 45,
+                        height: 45,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
           ),
           const SizedBox(width: 10),
           Expanded(

--- a/lib/pages/user_view_page.dart
+++ b/lib/pages/user_view_page.dart
@@ -177,16 +177,33 @@ class _UserViewPageState extends State<UserViewPage> {
             height: 50,
             decoration: const BoxDecoration(
               shape: BoxShape.circle,
+              color: Colors.grey,
             ),
             child: ClipRRect(
               borderRadius: const BorderRadius.all(Radius.circular(100)),
               child: SizedBox.fromSize(
-                size: const Size.fromRadius(48),
-                child: _userProfileModel.picture == null
-                    ? Container()
-                    : Image.network(
-                        fit: BoxFit.cover,
-                        _userProfileModel.picture.toString()),
+                size: const Size.fromRadius(25),
+                child: Image.network(
+                  fit: BoxFit.cover,
+                  _userProfileModel.picture ?? "null",
+                  // 정상적인 이미지 로드에 실패했을 경우
+                  // warning 아이콘 표시하기
+                  errorBuilder: (BuildContext context, Object error,
+                      StackTrace? stackTrace) {
+                    debugPrint("$error");
+                    return SizedBox(
+                      child: SvgPicture.asset(
+                        "assets/icons/warning.svg",
+                        colorFilter: const ColorFilter.mode(
+                          Colors.black,
+                          BlendMode.srcIn,
+                        ),
+                        width: 45,
+                        height: 45,
+                      ),
+                    );
+                  },
+                ),
               ),
             ),
           ),

--- a/lib/pages/user_view_page.dart
+++ b/lib/pages/user_view_page.dart
@@ -16,6 +16,7 @@ import 'package:new_ara_app/utils/time_utils.dart';
 import 'package:new_ara_app/pages/post_view_page.dart';
 import 'package:new_ara_app/utils/slide_routing.dart';
 import 'package:new_ara_app/providers/notification_provider.dart';
+import 'package:new_ara_app/utils/profile_image.dart';
 
 /// 유저 관련 정보 페이지 뷰, 이벤트 처리를 모두 관리하는 StatefulWidget
 class UserViewPage extends StatefulWidget {
@@ -183,27 +184,7 @@ class _UserViewPageState extends State<UserViewPage> {
               borderRadius: const BorderRadius.all(Radius.circular(100)),
               child: SizedBox.fromSize(
                 size: const Size.fromRadius(25),
-                child: Image.network(
-                  fit: BoxFit.cover,
-                  _userProfileModel.picture ?? "null",
-                  // 정상적인 이미지 로드에 실패했을 경우
-                  // warning 아이콘 표시하기
-                  errorBuilder: (BuildContext context, Object error,
-                      StackTrace? stackTrace) {
-                    debugPrint("$error");
-                    return SizedBox(
-                      child: SvgPicture.asset(
-                        "assets/icons/warning.svg",
-                        colorFilter: const ColorFilter.mode(
-                          Colors.black,
-                          BlendMode.srcIn,
-                        ),
-                        width: 45,
-                        height: 45,
-                      ),
-                    );
-                  },
-                ),
+                child: buildProfileImage(_userProfileModel.picture, 45, 45),
               ),
             ),
           ),

--- a/lib/pages/user_view_page.dart
+++ b/lib/pages/user_view_page.dart
@@ -184,6 +184,7 @@ class _UserViewPageState extends State<UserViewPage> {
               borderRadius: const BorderRadius.all(Radius.circular(100)),
               child: SizedBox.fromSize(
                 size: const Size.fromRadius(25),
+                // 이미지 링크를 확인한 후 null인 이미지는 warning.svg를 빌드
                 child: buildProfileImage(_userProfileModel.picture, 45, 45),
               ),
             ),

--- a/lib/utils/profile_image.dart
+++ b/lib/utils/profile_image.dart
@@ -22,6 +22,9 @@ import 'package:flutter_svg/flutter_svg.dart';
 ///   ),
 /// );
 Widget buildProfileImage(String? profileUri, double width, double height) {
+  // Image.network의 errorBuilder가 작동하였음에도 exception이 발생하는 경우 발견
+  // 또한 null인 이미지는 호출 후 error를 처리하기보다 미리 감지하는 것이 낫다고 판단하여
+  // 아래 삼항연산자 조건문을 적용함.
   return profileUri == null
       ? SizedBox(
           child: SvgPicture.asset(

--- a/lib/utils/profile_image.dart
+++ b/lib/utils/profile_image.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// profileUri에 있는 이미지를 주어진 width, height로 빌드함.
+/// 이미지 로드에 실패한 경우 assets/icons/warning.svg를 리턴.
+/// PostViewPage, UserPage, UserViewPage, ProfileEditPage에서 사용.
+/// 위 페이지 모두 공통된 형식으로 사용하여 함수로 리팩토링함.
+/// ```
+/// Container(
+///   width: 30,
+///   height: 30,
+///   decoration: const BoxDecoration(
+///     shape: BoxShape.circle,
+///     color: Colors.grey,
+///   ),
+///   child: ClipRRect(
+///     borderRadius: const BorderRadius.all(Radius.circular(100)),
+///     child: SizedBox.fromSize(
+///       size: const Size.fromRadius(15),
+///       child: buildProfileImage(profileUri, width, height),
+///     ),
+///   ),
+/// );
+Widget buildProfileImage(String? profileUri, double width, double height) {
+  return profileUri == null
+      ? SizedBox(
+          child: SvgPicture.asset(
+            "assets/icons/warning.svg",
+            colorFilter: const ColorFilter.mode(
+              Colors.black,
+              BlendMode.srcIn,
+            ),
+            width: width,
+            height: height,
+          ),
+        )
+      : Image.network(
+          fit: BoxFit.cover,
+          profileUri.toString(),
+          // 정상적인 이미지 로드에 실패했을 경우
+          // warning 아이콘 표시하기
+          errorBuilder:
+              (BuildContext context, Object error, StackTrace? stackTrace) {
+            debugPrint("PostViewPage creator: $error");
+            return SizedBox(
+              child: SvgPicture.asset(
+                "assets/icons/warning.svg",
+                colorFilter: const ColorFilter.mode(
+                  Colors.black,
+                  BlendMode.srcIn,
+                ),
+                width: width,
+                height: height,
+              ),
+            );
+          },
+        );
+}

--- a/lib/utils/profile_image.dart
+++ b/lib/utils/profile_image.dart
@@ -21,6 +21,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 ///     ),
 ///   ),
 /// );
+/// ```
 Widget buildProfileImage(String? profileUri, double width, double height) {
   // Image.network의 errorBuilder가 작동하였음에도 exception이 발생하는 경우 발견
   // 또한 null인 이미지는 호출 후 error를 처리하기보다 미리 감지하는 것이 낫다고 판단하여

--- a/lib/widgets/dialogs.dart
+++ b/lib/widgets/dialogs.dart
@@ -237,8 +237,10 @@ class _ReportDialogState extends State<ReportDialog> {
 /// PostViewPage의 댓글 삭제 기능에 사용되는 Dialog
 class DeleteDialog extends StatelessWidget {
   final UserProvider userProvider;
-  /// PostViewPage의 context. 
+
+  /// PostViewPage의 context.
   final BuildContext targetContext;
+
   /// '확인' 버튼을 눌렀을 때 적용되는 onTap 메서드
   final void Function()? onTap;
 
@@ -338,7 +340,6 @@ class DeleteDialog extends StatelessWidget {
         ),
       ),
     );
-  
   }
 }
 
@@ -416,13 +417,13 @@ class _BlockedUserDialogState extends State<BlockedUserDialog> {
                         left: 15, right: 15, top: 5, bottom: 5),
                     child: const Center(
                       child: Text(
-                      "차단한 유저가 없습니다",
-                      style: TextStyle(
-                        color: Colors.black,
-                        fontSize: 15,
-                        fontWeight: FontWeight.w500,
+                        "차단한 유저가 없습니다",
+                        style: TextStyle(
+                          color: Colors.black,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w500,
+                        ),
                       ),
-                    ),
                     ),
                   )
                 : Container(
@@ -440,7 +441,8 @@ class _BlockedUserDialogState extends State<BlockedUserDialog> {
                           height: 50,
                           child: Row(
                             children: [
-                              // 사용자 프로필 이미지 표시(null이 아닌 경우)
+                              // 사용자 프로필 이미지 표시
+                              // 이미지 링크가 null일 경우 warning 아이콘 표시
                               Container(
                                 width: 40,
                                 height: 40,
@@ -448,19 +450,36 @@ class _BlockedUserDialogState extends State<BlockedUserDialog> {
                                   shape: BoxShape.circle,
                                   color: Colors.grey,
                                 ),
-                                child: blockedUser.user.profile.picture == null
-                                    ? Container()
-                                    : ClipRRect(
-                                        borderRadius: const BorderRadius.all(
-                                            Radius.circular(100)),
-                                        child: SizedBox.fromSize(
-                                          size: const Size.fromRadius(40),
-                                          child: Image.network(
-                                              fit: BoxFit.cover,
-                                              blockedUser
-                                                  .user.profile.picture!),
-                                        ),
-                                      ),
+                                child: ClipRRect(
+                                  borderRadius: const BorderRadius.all(
+                                      Radius.circular(100)),
+                                  child: SizedBox.fromSize(
+                                    size: const Size.fromRadius(20),
+                                    child: Image.network(
+                                      fit: BoxFit.cover,
+                                      blockedUser.user.profile.nickname ??
+                                          "null",
+                                      // 정상적인 이미지 로드에 실패했을 경우
+                                      // warning 아이콘 표시하기
+                                      errorBuilder: (BuildContext context,
+                                          Object error,
+                                          StackTrace? stackTrace) {
+                                        debugPrint("$error");
+                                        return SizedBox(
+                                          child: SvgPicture.asset(
+                                            "assets/icons/warning.svg",
+                                            colorFilter: const ColorFilter.mode(
+                                              Colors.black,
+                                              BlendMode.srcIn,
+                                            ),
+                                            width: 35,
+                                            height: 35,
+                                          ),
+                                        );
+                                      },
+                                    ),
+                                  ),
+                                ),
                               ),
                               const SizedBox(width: 20),
                               Expanded(


### PR DESCRIPTION
Add(profile_image.dart): 이미지 null처리 로직 함수화
Fix(post_view_page.dart): 글 작성자 프로필, 댓글 작성자 프로필 이미지 null인 경우 처리
Fix(user_view_page.dart): 사용자 프로필 이미지 null인 경우 처리
Fix(user_page.dart): 사용자 프로필 이미지 null인 경우 처리
Fix(profile_edit_page.dart): 사용자 프로필 이미지 null인 경우 처리

**중간에 에러 처리 방식을 변경하여 커밋이 다소 많은 편인데 Add(profile_image.dart): null처리로직 함수화 커밋(1e87df8)부터 리뷰하셔도 괜찮을 것 같습니다.**

이미지를 로드하기 전 uri를 검사하여 이미지 uri가 null인 경우에 assets/icons/warning.svg를 로드하도록 처리하였습니다.
그리고 uri가 null인 것을 제외한 다른 exception을 처리하기 위하여 Image.network의 errorBuilder를 설정하였습니다.
![image](https://github.com/sparcs-kaist/new-ara-app/assets/48672097/3fcdfc3a-db2b-4db3-8687-e2a6bc4774ef)
