### PR TITLE
IOS 첨부파일 다운로드 에러 해결

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -9,6 +9,11 @@
     <key>NSMicrophoneUsageDescription</key>
     <string>This is used for image_picker 0.8.7+5</string>
 
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
+    <key>UIFileSharingEnabled</key>
+    <true/>
+
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/lib/utils/post_view_utils.dart
+++ b/lib/utils/post_view_utils.dart
@@ -177,12 +177,14 @@ class FileController {
     late Directory directory;
     if (Platform.isIOS) {
       directory = await getApplicationDocumentsDirectory();
+      debugPrint("ios download path: ${directory.path}");
     } else {
       directory = Directory('/storage/emulated/0/Download');
       if (!await directory.exists()) {
         directory =
             (await getExternalStorageDirectory())!; // Android 에서는 존재가 보장됨
       }
+      debugPrint("android download path: ${directory.path}");
     }
     return directory.path;
   }


### PR DESCRIPTION
문제상황: IOS에서 파일 다운로드를 할 경우 다운로드가 성공하였음에도 파일을 확인할 수 없는 에러가 발생했었음.
원인: 파일이 기기의 app document에 설치는 제대로 되었으나, file provider가 모든 앱의 파일을 읽을 수 있는 것이 아니라 읽을 수 있게 허용된 앱의 파일만 읽어서 표시하여 다운로드는 되었지만 정작 사용자에게는 보이지 않았던 것
해결방법: Info.plist에 LSSupportsOpeningDocumentsInPlace, UIFileSharingEnabled를 true로 설정하여 해결 가능
- LSSupportsOpeningDocumentsInPlace: IOS 및 third-party file provider 의 파일에 new-ara-app이 접근할 수 있음
- UIFileSharingEnabled: LSSupportsOpeningDocumentsInPlace와 함께 쓰였을 때 file provider가 app document의 모든 문서에 접근할 수 있게 해줌.

iOS simulator에서는 작동을 확인했으나 iOS 실물 기기에서 확인한번 부탁드립니다.