### PR TITLE
Feature(slide_routing.dart): back swipe 적용하기

### DIFF
--- a/lib/utils/slide_routing.dart
+++ b/lib/utils/slide_routing.dart
@@ -1,19 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
 Route slideRoute(Widget dst) {
-  return PageRouteBuilder(
-    pageBuilder: (context, animation, secondaryAnimation) => dst,
-    transitionsBuilder: ((context, animation, secondaryAnimation, child) {
-      var begin = const Offset(1, 0);
-      var end = const Offset(0, 0);
-      var curve = Curves.ease;
-
-      var tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
-      var offsetAnimation = animation.drive(tween);
-      return SlideTransition(
-        position: offsetAnimation,
-        child: child,
-      );
-    }),
+  // iOS, Android에서 모두 back swipe 적용
+  // TODO: Android에서 back swipe 적용할지 여부 논의 (2023.01.24)
+  return CupertinoPageRoute(
+    builder: (context) => dst,
   );
+  // return PageRouteBuilder(
+  //   pageBuilder: (context, animation, secondaryAnimation) => dst,
+  //   transitionsBuilder: ((context, animation, secondaryAnimation, child) {
+  //     var begin = const Offset(1, 0);
+  //     var end = const Offset(0, 0);
+  //     var curve = Curves.ease;
+
+  //     var tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+  //     var offsetAnimation = animation.drive(tween);
+  //     return SlideTransition(
+  //       position: offsetAnimation,
+  //       child: child,
+  //     );
+  //   }),
+  // );
 }


### PR DESCRIPTION
CupertinoPageRoute를 이용해서 back swipe 제스처를 인식하도록 하였습니다.
우선 이 기능을 iOS, Android에서 모두 사용할 수 있도록 해두었습니다.
Android에서는 기존의 방식을 유지할 지, back swipe를 사용할 수 있도록 CupertinoPageRoute를 적용할 지 논의가 필요할 것 같습니다.
Android 실물기기, iOS simulator에서 잘 동작하는 것을 확인하였습니다. iOS 실물 기기에서 잘 동작하는지 확인 부탁드립니다.
(만약 이미 밀어서 뒤로가기 개발하신 상태라면 저에게 말씀해주시면 이 PR은 삭제하도록 하겠습니다)