### PR TITLE
SPARCS SSO Facebook, Twitter 로그인 비활성화 (iOS 한정)

### DIFF
--- a/lib/constants/url_info.dart
+++ b/lib/constants/url_info.dart
@@ -1,3 +1,4 @@
 //const newAraDefaultUrl = "https://newara.dev.sparcs.org";
 const newAraDefaultUrl = "https://newara.dev.sparcs.org";
 const newAraAuthority = "newara.dev.sparcs.org";
+const sparcsSSODefaultUrl = "https://sparcssso.kaist.ac.kr";

--- a/lib/pages/sparcs_sso_page.dart
+++ b/lib/pages/sparcs_sso_page.dart
@@ -91,7 +91,7 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
             debugPrint('curUrl: $curUrl');
             /* /api/users/sso_login/가 성공적으로 실행되어 client_id, state를 발급받았지만
                소셜 로그인 비활성화가 되어있지 않은 경우, 관련 파리미터를 추가하려 리로드함. */
-            if (curUrl.startsWith(
+            if (Platform.isIOS && curUrl.startsWith(
                     'https://sparcssso.kaist.ac.kr/account/login/?next=/api/v2/token/require/') &&
                 curUrl.contains('social_enabled') == false) {
               // 소설 로그인 비활성화를 위해 social_enabled, show_disabled_button 파라미터를 모두 0으로 설정.
@@ -101,7 +101,7 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
             /* 로그인 페이지에서 SPARCS SSO 내의 다른 페이지를 방문하였다가 다시 로그인 페이지로 돌아오는 경우,
                client_id, state가 아직 발급되지 않은 상태이기 때문에 소셜 로그인 비활성화를 할 수 없음.
                따라서 /api/users/sso_login/으로 리다이렉트함. */
-            else if (url == 'https://sparcssso.kaist.ac.kr/account/login/') {
+            else if (Platform.isIOS && url == 'https://sparcssso.kaist.ac.kr/account/login/') {
               await _controller.runJavaScript(
                   "window.location.href = '$newAraDefaultUrl/api/users/sso_login/'");
             } else {

--- a/lib/pages/sparcs_sso_page.dart
+++ b/lib/pages/sparcs_sso_page.dart
@@ -90,8 +90,9 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
             debugPrint('curUrl: $curUrl');
             /* /api/users/sso_login/가 성공적으로 실행되어 client_id, state를 발급받았지만
                소셜 로그인 비활성화가 되어있지 않은 경우, 관련 파리미터를 추가하려 리로드함. */
-            if (Platform.isIOS && curUrl.startsWith(
-                    'https://sparcssso.kaist.ac.kr/account/login/?next=/api/v2/token/require/') &&
+            if (Platform.isIOS &&
+                curUrl.startsWith(
+                    '$sparcsSSODefaultUrl/account/login/?next=/api/v2/token/require/') &&
                 curUrl.contains('social_enabled') == false) {
               // 소설 로그인 비활성화를 위해 social_enabled, show_disabled_button 파라미터를 모두 0으로 설정.
               await _controller.runJavaScript(
@@ -100,7 +101,8 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
             /* 로그인 페이지에서 SPARCS SSO 내의 다른 페이지를 방문하였다가 다시 로그인 페이지로 돌아오는 경우,
                client_id, state가 아직 발급되지 않은 상태이기 때문에 소셜 로그인 비활성화를 할 수 없음.
                따라서 /api/users/sso_login/으로 리다이렉트함. */
-            else if (Platform.isIOS && url == 'https://sparcssso.kaist.ac.kr/account/login/') {
+            else if (Platform.isIOS &&
+                url == '$sparcsSSODefaultUrl/account/login/') {
               await _controller.runJavaScript(
                   "window.location.href = '$newAraDefaultUrl/api/users/sso_login/'");
             } else {
@@ -120,8 +122,7 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
         },
       ))
       // 시작 URL 로딩
-      ..loadRequest(
-          Uri.parse('https://newara.dev.sparcs.org/api/users/sso_login/'));
+      ..loadRequest(Uri.parse('$newAraDefaultUrl/api/users/sso_login/'));
   }
 
   @override

--- a/lib/pages/sparcs_sso_page.dart
+++ b/lib/pages/sparcs_sso_page.dart
@@ -46,6 +46,18 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
       ..setBackgroundColor(const Color(0x00000000))
       // 네비게이션 대리자 설정
       ..setNavigationDelegate(NavigationDelegate(
+        onNavigationRequest: (NavigationRequest request) async {
+          Uri uri = Uri.parse(request.url);
+          // SPARCS SSO 페이지에서 개발팀, 관리자에게 연락하기 기능이
+          // mailto scheme을 사용하는데 웹뷰에서 잘 처리가 되지 않아 비활성화시켜둠.
+          if (uri.scheme == 'mailto') {
+            // TODO: 사용자 알림 메시지 구현하기
+            debugPrint("아라앱에서 mailto scheme은 아직 관련 구현이 되어있지 않음(2023.01.24)");
+            return NavigationDecision.prevent;
+          }
+          // mailto를 제외한 scheme에 대해서는 navigate 처리.
+          return NavigationDecision.navigate;
+        },
         // 페이지 로딩 상태를 출력
         onProgress: (int progress) {
           debugPrint('WebView가 로딩 중입니다 (진행률: $progress)');

--- a/lib/pages/sparcs_sso_page.dart
+++ b/lib/pages/sparcs_sso_page.dart
@@ -6,7 +6,6 @@ import 'package:new_ara_app/providers/user_provider.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:new_ara_app/widgets/loading_indicator.dart';
 import 'package:provider/provider.dart';
-import 'package:dio/dio.dart';
 
 /// SparcsSSOPage
 /// Sparcs SSO(단일 서명 인증) 처리를 담당하는 Flutter 페이지 위젯입니다.

--- a/lib/pages/sparcs_sso_page.dart
+++ b/lib/pages/sparcs_sso_page.dart
@@ -6,6 +6,7 @@ import 'package:new_ara_app/providers/user_provider.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:new_ara_app/widgets/loading_indicator.dart';
 import 'package:provider/provider.dart';
+import 'package:dio/dio.dart';
 
 /// SparcsSSOPage
 /// Sparcs SSO(단일 서명 인증) 처리를 담당하는 Flutter 페이지 위젯입니다.
@@ -28,62 +29,80 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
   // TODO: 이 userID가 왜 쓰이는 지, 왜 남겨두었는지 알아보기
   int userID = 0;
 
+  Future<String> getClientIDState() async {
+    // /api/sso_login으로 요청 보내기
+    Dio _dio = Dio();
+    _dio.options.followRedirects = true;
+    _dio.options.responseType = ResponseType.plain;
+    final String apiUrl = "https://newara.dev.sparcs.org/api/users/sso_login/";
+    var response = await _dio.get(apiUrl);
+    return response.realUri.toString();
+  }
+
   @override
   void initState() {
     super.initState();
 
-    // 쿠키 초기화
-    // TODO: 여기 웹뷰에서 쿠키 초기화하면 모든 웹뷰에서 쿠키가 초기화 되는 것인지 알기
-    WebViewCookieManager().clearCookies();
+    getClientIDState().then((path) {
+      debugPrint('real path: $path');
+      
+      // 쿠키 초기화
+      // 다른 쿠키도 모두 초기화되는지 알아야 함
+      WebViewCookieManager().clearCookies();
 
-    _controller = WebViewController()
-      // JavaScript 활성화
-      ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      // WebView 배경색 설정
-      ..setBackgroundColor(const Color(0x00000000))
-      // 네비게이션 대리자 설정
-      ..setNavigationDelegate(NavigationDelegate(
-        // 페이지 로딩 상태를 출력
-        onProgress: (int progress) {
-          debugPrint('WebView가 로딩 중입니다 (진행률: $progress)');
-        },
-        // 페이지 로딩 시작 시
-        onPageStarted: (String url) {
-          // 로딩 표시기 활성화
-          setState(() => isVisible = false);
-        },
-        // 페이지 로딩 완료 시
-        onPageFinished: (String url) async {
-          // 특정 URL로 끝나면 로그인 성공으로 판단
-          if (url.endsWith('$newAraDefaultUrl/') && mounted) {
-            var userProvider = context.read<UserProvider>();
-            debugPrint("main.dart:로그인 성공");
+      _controller = WebViewController()
+        // JavaScript 활성화
+        ..setJavaScriptMode(JavaScriptMode.unrestricted)
+        // WebView 배경색 설정
+        ..setBackgroundColor(const Color(0x00000000))
+        // 네비게이션 대리자 설정
+        ..setNavigationDelegate(NavigationDelegate(
+          // 페이지 로딩 상태를 출력
+          onProgress: (int progress) {
+            debugPrint('WebView가 로딩 중입니다 (진행률: $progress)');
+          },
+          // 페이지 로딩 시작 시
+          onPageStarted: (String url) {
+            debugPrint("Start to load $url");
+            // 로딩 표시기 활성화
+            setState(() => isVisible = false);
+          },
+          // 페이지 로딩 완료 시
+          onPageFinished: (String url) async {
+            // 특정 URL로 끝나면 로그인 성공으로 판단
+            if (url.endsWith('$newAraDefaultUrl/') && mounted) {
+              var userProvider = context.read<UserProvider>();
+              debugPrint("main.dart:로그인 성공");
 
-            FlutterSecureStorage secureStorage = const FlutterSecureStorage();
+              FlutterSecureStorage secureStorage = const FlutterSecureStorage();
 
-            debugPrint("현재 URL은 $url 입니다");
+              debugPrint("현재 URL은 $url 입니다");
 
-            await userProvider.setCookiesFromUrl(url);
-            await userProvider.apiMeUserInfo(message: "sparscssso");
-            userProvider.setHasData(true);
+              await userProvider.setCookiesFromUrl(url);
+              await userProvider.apiMeUserInfo(message: "sparscssso");
+              userProvider.setHasData(true);
 
-            String cookieString = userProvider.getCookiesToString();
-            await secureStorage.write(key: 'cookie', value: cookieString);
-          } else if (mounted) {
-            // 로딩 완료 후 WebView 활성화
-            setState(() {
-              isVisible = true;
-            });
-          }
-        },
-        // WebView 리소스 오류 발생 시
-        onWebResourceError: (WebResourceError error) {
-          debugPrint(
-              '코드: ${error.errorCode}\n설명: ${error.description}\n오류 유형: ${error.errorType}\n메인 프레임에 대한 것인가? ${error.isForMainFrame}');
-        },
-      ))
-      // 시작 URL 로딩
-      ..loadRequest(Uri.parse('$newAraDefaultUrl/api/users/sso_login/'));
+              String cookieString = userProvider.getCookiesToString();
+              await secureStorage.write(key: 'cookie', value: cookieString);
+            } else if (mounted) {
+              debugPrint("Finish loading url: $url");
+              // 로딩 완료 후 WebView 활성화
+              setState(() {
+                isVisible = true;
+              });
+            } else {
+              debugPrint("not mounted");
+            }
+          },
+          // WebView 리소스 오류 발생 시
+          onWebResourceError: (WebResourceError error) {
+            debugPrint(
+                '코드: ${error.errorCode}\n설명: ${error.description}\n오류 유형: ${error.errorType}\n메인 프레임에 대한 것인가? ${error.isForMainFrame}');
+          },
+        ))
+        // 시작 URL 로딩
+        ..loadRequest(Uri.parse('https://sparcssso.kaist.ac.kr$path%26social_enabled%3D0%26show_disabled_button%3D0'));
+    });
   }
 
   @override

--- a/lib/pages/sparcs_sso_page.dart
+++ b/lib/pages/sparcs_sso_page.dart
@@ -67,15 +67,6 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
           debugPrint("Start to load $url");
           // 로딩 표시기 활성화
           setState(() => isVisible = false);
-          /* 
-          로그인 페이지에서 SPARCS SSO 내의 다른 페이지를 방문하였다가 다시 로그인 페이지로 돌아오는 경우,
-          client_id, state가 아직 발급되지 않은 상태이기 때문에 소셜 로그인 비활성화를 할 수 없음.
-          따라서 /api/users/sso_login/으로 리다이렉트함.
-           */
-          if (url == 'https://sparcssso.kaist.ac.kr/account/login/') {
-            await _controller.runJavaScript(
-                "window.location.href = '$newAraDefaultUrl/api/users/sso_login/'");
-          }
         },
         // 페이지 로딩 완료 시
         onPageFinished: (String url) async {
@@ -103,15 +94,22 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
             if (curUrl.startsWith(
                     'https://sparcssso.kaist.ac.kr/account/login/?next=/api/v2/token/require/') &&
                 curUrl.contains('social_enabled') == false) {
-              debugPrint("NO SOCIAL ENABLED");
               // 소설 로그인 비활성화를 위해 social_enabled, show_disabled_button 파라미터를 모두 0으로 설정.
               await _controller.runJavaScript(
                   "window.location.href = '$curUrl%26social_enabled%3D0%26show_disabled_button%3D0';");
             }
-            // 로딩 완료 후 WebView 활성화
-            setState(() {
-              isVisible = true;
-            });
+            /* 로그인 페이지에서 SPARCS SSO 내의 다른 페이지를 방문하였다가 다시 로그인 페이지로 돌아오는 경우,
+               client_id, state가 아직 발급되지 않은 상태이기 때문에 소셜 로그인 비활성화를 할 수 없음.
+               따라서 /api/users/sso_login/으로 리다이렉트함. */
+            else if (url == 'https://sparcssso.kaist.ac.kr/account/login/') {
+              await _controller.runJavaScript(
+                  "window.location.href = '$newAraDefaultUrl/api/users/sso_login/'");
+            } else {
+              // 로딩 완료 후 WebView 활성화
+              setState(() {
+                isVisible = true;
+              });
+            }
           } else {
             debugPrint("not mounted");
           }

--- a/lib/pages/sparcs_sso_page.dart
+++ b/lib/pages/sparcs_sso_page.dart
@@ -29,80 +29,90 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
   // TODO: 이 userID가 왜 쓰이는 지, 왜 남겨두었는지 알아보기
   int userID = 0;
 
-  Future<String> getClientIDState() async {
-    // /api/sso_login으로 요청 보내기
-    Dio _dio = Dio();
-    _dio.options.followRedirects = true;
-    _dio.options.responseType = ResponseType.plain;
-    final String apiUrl = "https://newara.dev.sparcs.org/api/users/sso_login/";
-    var response = await _dio.get(apiUrl);
-    return response.realUri.toString();
-  }
-
   @override
   void initState() {
     super.initState();
 
-    getClientIDState().then((path) {
-      debugPrint('real path: $path');
-      
-      // 쿠키 초기화
-      // 다른 쿠키도 모두 초기화되는지 알아야 함
-      WebViewCookieManager().clearCookies();
+    debugPrint("initState invoked!!!");
 
-      _controller = WebViewController()
-        // JavaScript 활성화
-        ..setJavaScriptMode(JavaScriptMode.unrestricted)
-        // WebView 배경색 설정
-        ..setBackgroundColor(const Color(0x00000000))
-        // 네비게이션 대리자 설정
-        ..setNavigationDelegate(NavigationDelegate(
-          // 페이지 로딩 상태를 출력
-          onProgress: (int progress) {
-            debugPrint('WebView가 로딩 중입니다 (진행률: $progress)');
-          },
-          // 페이지 로딩 시작 시
-          onPageStarted: (String url) {
-            debugPrint("Start to load $url");
-            // 로딩 표시기 활성화
-            setState(() => isVisible = false);
-          },
-          // 페이지 로딩 완료 시
-          onPageFinished: (String url) async {
-            // 특정 URL로 끝나면 로그인 성공으로 판단
-            if (url.endsWith('$newAraDefaultUrl/') && mounted) {
-              var userProvider = context.read<UserProvider>();
-              debugPrint("main.dart:로그인 성공");
+    // 쿠키 초기화
+    // 다른 쿠키도 모두 초기화되는지 알아야 함
+    WebViewCookieManager().clearCookies();
 
-              FlutterSecureStorage secureStorage = const FlutterSecureStorage();
+    _controller = WebViewController()
+      // JavaScript 활성화
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      // WebView 배경색 설정
+      ..setBackgroundColor(const Color(0x00000000))
+      // 네비게이션 대리자 설정
+      ..setNavigationDelegate(NavigationDelegate(
+        // 페이지 로딩 상태를 출력
+        onProgress: (int progress) {
+          debugPrint('WebView가 로딩 중입니다 (진행률: $progress)');
+        },
+        // 페이지 로딩 시작 시
+        onPageStarted: (String url) async {
+          debugPrint("Start to load $url");
+          // 로딩 표시기 활성화
+          setState(() => isVisible = false);
+          /* 
+          로그인 페이지에서 SPARCS SSO 내의 다른 페이지를 방문하였다가 다시 로그인 페이지로 돌아오는 경우,
+          client_id, state가 아직 발급되지 않은 상태이기 때문에 소셜 로그인 비활성화를 할 수 없음.
+          따라서 /api/users/sso_login/으로 리다이렉트함.
+           */
+          if (url == 'https://sparcssso.kaist.ac.kr/account/login/') {
+            await _controller.runJavaScript(
+                "window.location.href = '$newAraDefaultUrl/api/users/sso_login/'");
+          }
+        },
+        // 페이지 로딩 완료 시
+        onPageFinished: (String url) async {
+          debugPrint("Finish loading url: $url");
+          // 특정 URL로 끝나면 로그인 성공으로 판단
+          if (url.endsWith('$newAraDefaultUrl/') && mounted) {
+            var userProvider = context.read<UserProvider>();
+            debugPrint("main.dart:로그인 성공");
 
-              debugPrint("현재 URL은 $url 입니다");
+            FlutterSecureStorage secureStorage = const FlutterSecureStorage();
 
-              await userProvider.setCookiesFromUrl(url);
-              await userProvider.apiMeUserInfo(message: "sparscssso");
-              userProvider.setHasData(true);
+            debugPrint("현재 URL은 $url 입니다");
 
-              String cookieString = userProvider.getCookiesToString();
-              await secureStorage.write(key: 'cookie', value: cookieString);
-            } else if (mounted) {
-              debugPrint("Finish loading url: $url");
-              // 로딩 완료 후 WebView 활성화
-              setState(() {
-                isVisible = true;
-              });
-            } else {
-              debugPrint("not mounted");
+            await userProvider.setCookiesFromUrl(url);
+            await userProvider.apiMeUserInfo(message: "sparscssso");
+            userProvider.setHasData(true);
+
+            String cookieString = userProvider.getCookiesToString();
+            await secureStorage.write(key: 'cookie', value: cookieString);
+          } else if (mounted) {
+            String curUrl = (await _controller.currentUrl()).toString();
+            debugPrint('curUrl: $curUrl');
+            /* /api/users/sso_login/가 성공적으로 실행되어 client_id, state를 발급받았지만
+               소셜 로그인 비활성화가 되어있지 않은 경우, 관련 파리미터를 추가하려 리로드함. */
+            if (curUrl.startsWith(
+                    'https://sparcssso.kaist.ac.kr/account/login/?next=/api/v2/token/require/') &&
+                curUrl.contains('social_enabled') == false) {
+              debugPrint("NO SOCIAL ENABLED");
+              // 소설 로그인 비활성화를 위해 social_enabled, show_disabled_button 파라미터를 모두 0으로 설정.
+              await _controller.runJavaScript(
+                  "window.location.href = '$curUrl%26social_enabled%3D0%26show_disabled_button%3D0';");
             }
-          },
-          // WebView 리소스 오류 발생 시
-          onWebResourceError: (WebResourceError error) {
-            debugPrint(
-                '코드: ${error.errorCode}\n설명: ${error.description}\n오류 유형: ${error.errorType}\n메인 프레임에 대한 것인가? ${error.isForMainFrame}');
-          },
-        ))
-        // 시작 URL 로딩
-        ..loadRequest(Uri.parse('https://sparcssso.kaist.ac.kr$path%26social_enabled%3D0%26show_disabled_button%3D0'));
-    });
+            // 로딩 완료 후 WebView 활성화
+            setState(() {
+              isVisible = true;
+            });
+          } else {
+            debugPrint("not mounted");
+          }
+        },
+        // WebView 리소스 오류 발생 시
+        onWebResourceError: (WebResourceError error) {
+          debugPrint(
+              '코드: ${error.errorCode}\n설명: ${error.description}\n오류 유형: ${error.errorType}\n메인 프레임에 대한 것인가? ${error.isForMainFrame}');
+        },
+      ))
+      // 시작 URL 로딩
+      ..loadRequest(
+          Uri.parse('https://newara.dev.sparcs.org/api/users/sso_login/'));
   }
 
   @override


### PR DESCRIPTION
Feat(sparcs_sso_page.dart): iOS에 대해서 Facebook, Twitter 소셜 로그인을 제거했습니다(앱스토어 심사때문)
Fix(sparcs_sso_page.dart): SPARCS SSO 페이지를 웹뷰로 띄울 때 하단에 '개발팀', '관리자' 기능이 mailto scheme을 사용합니다. 현재 앱에서 mailto scheme 처리가 구현되어 있지 않기 때문에 우선 비활성화해두었습니다.
- 곧 사용자 메시지(ScaffoldMessenger 등등)을 만들게 되면 관련 알림 코드도 작성해두겠습니다(sparcs_sso_page.dart 내에 TODO 주석 처리해놓았습니다)

제거 방법은 client_id, state를 발급받은 상태에서 social_enabled, show_disabled_button 파라미터를 모두 0으로 설정하는 방법으로 구현이 가능합니다.
- [관련 SSO 문서](https://www.notion.so/sparcs/SSO-d9a6a434839e417bbe1185940bf68c55?pvs=4) 및 현 PR의 코드를 통해 자세히 확인하실 수 있습니다.

iOS simulator, Android 실물기기에서 정상작동을 확인하였습니다.