### PR TITLE
Fix(post_view_page.dart): 좋아요, 싫어요 버튼 다시 추가

### DIFF
--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -364,6 +364,8 @@ class _PostViewPageState extends State<PostViewPage> {
                                         ),
                                       ),
                                       const SizedBox(height: 10),
+                                      _buildVoteButtons(userProvider),
+                                      const SizedBox(height: 10),
                                       // 담아두기, 공유, 신고 버튼
                                       _buildUtilityButtons(userProvider),
                                       const SizedBox(height: 15),


### PR DESCRIPTION
어제 있었던 머지 이슈로....좋아요, 싫어요 버튼 빌드 함수가 빠져있어서 다시 추가했습니다. 로직은 바뀐게 없고 디자인만 변경되었습니다.