### PR TITLE
UserViewPage 무한로딩 해결

### DIFF
--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -508,7 +508,7 @@ class _PostViewPageState extends State<PostViewPage> {
     debugPrint("**********************************************");
     return InkWell(
       // 익명일 경우 작성자 정보확인이 불가하도록 함.
-      onTap: _article.name_type == 2
+      onTap: !isRegular(_article.name_type)
           ? null
           : () async {
               await Navigator.of(context).push(
@@ -557,7 +557,7 @@ class _PostViewPageState extends State<PostViewPage> {
           const SizedBox(width: 10),
           // 익명일 경우 작성자 정보 확인을 불가하도록 함.
           Visibility(
-            visible: _article.created_by.profile.nickname != "익명",
+            visible: isRegular(_article.name_type),
             child: SvgPicture.asset(
               'assets/icons/right_chevron.svg',
               colorFilter:
@@ -1020,7 +1020,7 @@ class _PostViewPageState extends State<PostViewPage> {
                     children: [
                       InkWell(
                         // 익명일 경우 댓글 작성자 정보 확인이 불가능하도록 함.
-                        onTap: curComment.name_type == 2
+                        onTap: !isRegular(curComment.name_type)
                             ? null
                             : () {
                                 Navigator.of(context).push(slideRoute(
@@ -1549,5 +1549,11 @@ class _PostViewPageState extends State<PostViewPage> {
       _setCommentMode(false, false);
     }
     return true;
+  }
+
+  /// 주어진 nameType에 따라 유저 정보를 볼 수 있는지 여부를 리턴하는 함수
+  /// PostViewPage에서 UserViewPage로 리다이렉트 될 수 있는지 여부를 나타냄.
+  bool isRegular(int? nameType) {
+    return nameType == 1;
   }
 }

--- a/lib/pages/user_view_page.dart
+++ b/lib/pages/user_view_page.dart
@@ -20,7 +20,9 @@ import 'package:new_ara_app/utils/profile_image.dart';
 import 'package:new_ara_app/utils/handle_hidden.dart';
 import 'package:new_ara_app/widgets/post_preview.dart';
 
+
 /// 유저 관련 정보 페이지 뷰, 이벤트 처리를 모두 관리하는 StatefulWidget
+/// **중요: name_type == 1 이 아닌 경우에 대해서는 사용하면 안됨.**
 class UserViewPage extends StatefulWidget {
   /// 정보 조회의 대상이되는 user의 ID.
   final int userID;


### PR DESCRIPTION
현재 아라 정책상, name_type이 1이 아닌 사용자에 대해서는 사용자 정보를 확인할 수 없게 되어있음.
그런데 앱에서 name_type == 2 (익명인 경우)는 잘 필터링했지만 name_type == 4와 같은 다른 경우를 체크하지 못해서 무한로딩이 발생함.
name_type == 1이 아니면 UserViewPage로 가지 않도록 수정하여 해결함.