### PR TITLE
is_hidden=true일 때 자신의 글 수정 불가능하게 변경

### DIFF
--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -945,7 +945,8 @@ class _PostViewPageState extends State<PostViewPage> {
                   ),
                 ),
               )
-            else // 자신의 글
+            // 자신의 글이며 숨겨지지 않았을 때
+            else if (_article.is_hidden == false)
               InkWell(
                 onTap: () async {
                   await Navigator.of(context).push(


### PR DESCRIPTION
# 기존 문제 상황
기존 앱에서는 자신의 글에 대해서는 수정 버튼이 보이게 되어 있었음. 그러나 자신의 글이라도 숨겨져있는 경우 수정 기능이 지원되지 않아 무한로딩이 발생했음.

# 해결 방법
수정 버튼이 보여지는 조건에 is_hidden=false를 추가하여 해결함.