### PR TITLE
Fix(post_view_page.dart): 댓글 닉네임 maxWidth 수정

### DIFF
--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -1189,7 +1189,7 @@ class _PostViewPageState extends State<PostViewPage> {
                             Container(
                                 constraints: BoxConstraints(
                                   maxWidth:
-                                      MediaQuery.of(context).size.width - 200,
+                                      MediaQuery.of(context).size.width - 250,
                                 ),
                                 child: Text(
                                   curComment.created_by.profile.nickname


### PR DESCRIPTION
댓글 닉네임에 오버플로우 처리가 제대로 안되있어서 추가했습니다.
# Before
<img width="427" alt="image" src="https://github.com/sparcs-kaist/new-ara-app/assets/48672097/e309fc6c-c4e8-4e3a-bf10-b78591d847ef">
# After
<img width="429" alt="image" src="https://github.com/sparcs-kaist/new-ara-app/assets/48672097/00d98671-ba70-46a7-8b3a-230b3c47ea20">

혹시 몰라서 다른 컴포넌트들고 오버플로우 관련 설정 한번씩 확인해보았습니다.