### PR TITLE
Fix: GestureDectector behavior 속성 변경

### DIFF
--- a/lib/pages/post_list_show_page.dart
+++ b/lib/pages/post_list_show_page.dart
@@ -168,6 +168,7 @@ class _PostListShowPageState extends State<PostListShowPage> {
         centerTitle: true,
         leadingWidth: 100,
         leading: GestureDetector(
+          behavior: HitTestBehavior.translucent,
           onTap: () => Navigator.pop(context),
           child: Stack(
             alignment: Alignment.centerLeft,

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -214,6 +214,7 @@ class _PostViewPageState extends State<PostViewPage> {
               centerTitle: true,
               leadingWidth: 200,
               leading: GestureDetector(
+                behavior: HitTestBehavior.translucent,
                 onTap: () => Navigator.pop(context),
                 child: Stack(
                   alignment: Alignment.centerLeft,

--- a/lib/pages/post_write_page.dart
+++ b/lib/pages/post_write_page.dart
@@ -1067,6 +1067,7 @@ class _PostWritePageState extends State<PostWritePage>
           Row(
             children: [
               GestureDetector(
+                behavior: HitTestBehavior.translucent,
                 onTap: () {
                   setState(() {
                     _selectedCheckboxes[0] = !_selectedCheckboxes[0]!;
@@ -1112,8 +1113,9 @@ class _PostWritePageState extends State<PostWritePage>
             ],
           ),
 
-        //TODO: 터치 부분이 너무 작아서 불편함.
+        
         GestureDetector(
+          behavior: HitTestBehavior.translucent,
           onTap: () {
             setState(() {
               //성인 체크 박스
@@ -1161,6 +1163,7 @@ class _PostWritePageState extends State<PostWritePage>
           width: 15,
         ),
         GestureDetector(
+          behavior: HitTestBehavior.translucent,
           onTap: () {
             setState(() {
               //정치 체크 박스

--- a/lib/pages/setting_page.dart
+++ b/lib/pages/setting_page.dart
@@ -315,7 +315,7 @@ class SettingPageState extends State<SettingPage> {
                   ),
                   child: SizedBox(
                     width: MediaQuery.of(context).size.width - 60,
-                    child: GestureDetector(
+                    child: InkWell(
                       onTap: () => _logout(),
                       child: const Center(
                         child: Text(

--- a/lib/pages/user_page.dart
+++ b/lib/pages/user_page.dart
@@ -323,6 +323,7 @@ class _UserPageState extends State<UserPage>
             width: 26,
             height: 21,
             child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
               onTap: () async {
                 await Navigator.push(
                   context,


### PR DESCRIPTION
기존: 자식들이 차지하고 있지 않는 화면 상 빈공간에는 gesture가 인식이 안됨
원인: behavior의 속성 때문
변경: behavior의 속성 deferToChild(default) -> translucent