### PR TITLE
'<', '>' 표시 문제 해결

### DIFF
--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -1434,7 +1434,8 @@ class _PostViewPageState extends State<PostViewPage> {
   /// _buildCommentListView에서 사용함.
   Widget _buildCommentContent(String content) {
     // HTML 태그가 존재하는지 검사 (완벽한 방법은 아님)
-    if (!content.contains('<')) {
+    // 아라 서버에 '<', '>'가 html 인코딩된 상태로 저장되어 <, > 대신 &lt, &gt 사용함
+    if (!(content.contains('&lt') && content.contains('&gt'))) {
       return Text(
         content,
         style: const TextStyle(

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -1450,7 +1450,7 @@ class _PostViewPageState extends State<PostViewPage> {
       style: const TextStyle(
         fontSize: 14,
         fontWeight: FontWeight.w400,
-        color: Colors.black,
+        color: Color(0xFF4A4A4A),
       ),
     );
   }

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -1433,22 +1433,25 @@ class _PostViewPageState extends State<PostViewPage> {
   /// 웹뷰로 로드, 나머지는 텍스트로 댓글을 로드하도록 함.
   /// _buildCommentListView에서 사용함.
   Widget _buildCommentContent(String content) {
-    // HTML 태그가 존재하는지 검사 (완벽한 방법은 아님)
-    // 아라 서버에 '<', '>'가 html 인코딩된 상태로 저장되어 <, > 대신 &lt, &gt 사용함
-    if (!(content.contains('&lt') && content.contains('&gt'))) {
-      return Text(
-        content,
-        style: const TextStyle(
-          fontSize: 14,
-          fontWeight: FontWeight.w400,
-          color: Colors.black,
-        ),
+    // html 태그에서 사용하는 '<', '>'의 경우 형태가 그대로 저장됨
+    // html 태그가 아닌 '<', '>'의 경우 '&lt;', '&gt;'로 인코딩되어 저장됨
+    // 따라서 위 두 가지 경우에 대해서는 웹뷰로 로드하고 나머지는 Text 위젲 사용.
+    if ((content.contains('<') && content.contains('>')) ||
+        content.contains('&lt;') ||
+        content.contains('&gt;')) {
+      return InArticleWebView(
+        content: getContentHtml(content),
+        initialHeight: 10,
+        isComment: true,
       );
     }
-    return InArticleWebView(
-      content: getContentHtml(content),
-      initialHeight: 10,
-      isComment: true,
+    return Text(
+      content,
+      style: const TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w400,
+        color: Colors.black,
+      ),
     );
   }
 


### PR DESCRIPTION
현재 경험적으로 보았을 때, 아라 서버에서 '<', '>'가 저장되는 방식이 아래 두 가지인 것 같습니다.
1. HTML 태그로 사용되었을 때
- '>', '<'가 문자 그대로 저장됨
2. 그 이외의 경우
- '&lt;', '&gt;'로 인코딩되어 저장됨

따라서 위 두 가지 경우에는 웹뷰로 로드하여 정상적으로 표시되도록 변경하였습니다.