### PR TITLE
Fix(post_view_page.dart): fix autoscroll height

### DIFF
--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -1645,7 +1645,7 @@ class _PostViewPageState extends State<PostViewPage> {
                       // 댓글 수정, 대댓글은 제외
                       if (!_isNestedComment && !_isModify) {
                         _scrollController.animateTo(
-                          _scrollController.position.maxScrollExtent + 30,
+                          _scrollController.position.maxScrollExtent + 72,
                           duration: const Duration(milliseconds: 500),
                           curve: Curves.easeOut,
                         );


### PR DESCRIPTION
댓글 작성 후 맨 하단으로 움직이는 픽셀 크기 수정했습니다.
댓글 한 줄 기준 72pixels 입니다.
댓글 블럭 사이즈(72pixels)만큼 움직입니다.

<hr>

변경후:

https://github.com/sparcs-kaist/new-ara-app/assets/5186472/aec40dc4-d477-4f56-b360-96f82ec0b627

