### PR TITLE
Feat/android fastlane

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,5 +83,7 @@ team_id("N5V8W52U3U") # Developer Portal Team ID
 cd android && bundle exec fastlane alpha && cd ../ios && bundle exec fastlane alpha
 ```
 
-배포 후, `pubspec.yaml`과 iOS Xcode 프로젝트 관련 파일들( `ios/Runner.xcodeproj/project.pbxproj`, `ios/Runner/Info.plist` )의 변경사항을 Discard 합니다.
+### 배포 후 작업
+- `pubspec.yaml` 변경 사항을 Discard 합니다.
+- iOS Xcode 프로젝트 관련 파일들( `ios/Runner.xcodeproj/project.pbxproj`, `ios/Runner/Info.plist` )의 변경사항을 Discard 합니다.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ bundle install
 - `android/fastlane/.env` : 아래와 같이 각자 개인이 발급 받은 GITHUB_API_TOKEN을 추가합니다. 
 
 ```env
-GITHUB_API_TOKEN=************************
+GITHUB_API_TOKEN=****************************************
 ```
 GITHUB_API_TOKEN 발급 받는 법: https://lifefun.tistory.com/161
 
@@ -54,12 +54,13 @@ keyAlias=upload
 ```
 
 ### Credentials(iOS)
-- `ios/fastlane/.env.default` : 아래와 같이 본인의 Apple ID 계정 정보를 입력합니다.
+- `ios/fastlane/.env.default` : 아래와 같이 본인의 Apple ID 계정 정보와 개인이 발급 받은 GITHUB_API_TOKEN를 입력합니다.
 
 ```env
 FASTLANE_USER=****@****.***
 FASTLANE_PASSWORD=********
 FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=****-****-****-****
+GITHUB_API_TOKEN=****************************************
 ```
 
 - `ios/fastlane/Appfile` : 아래와 같이 Apple ID 계정 정보를 입력합니다.
@@ -81,6 +82,13 @@ team_id("N5V8W52U3U") # Developer Portal Team ID
 
 ```bash
 cd android && bundle exec fastlane alpha && cd ../ios && bundle exec fastlane alpha
+```
+
+
+아래 예시처럼 하나의 플랫폼에도 배포가 가능합니다.
+
+```bash
+cd ios && bundle exec fastlane alpha
 ```
 
 ### 배포 후 작업

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,20 @@ gem install bundler
 bundle install
 ```
 
-### Credentials
+### Credentials(Android)
 
-- `android/fastlane/otlplus-fastlane.json` : Google Play 서비스 계정 JSON 파일
+- `android/fastlane/newara-fastlane.json` : Google Play 서비스 계정 JSON 파일
+
 - `android/fastlane/upload-keystore.jks` : Android App Signing Key for Upload Google Play
+
+- `android/fastlane/.env` : 아래와 같이 각자 개인이 발급 받은 GITHUB_API_TOKEN을 추가합니다. 
+
+```env
+GITHUB_API_TOKEN=************************
+```
+GITHUB_API_TOKEN 발급 받는 법: https://lifefun.tistory.com/161
+
+
 - `android/key.properties` : 아래와 같이 Signing Key 정보를 입력합니다.
 
 ```env
@@ -43,7 +53,8 @@ keyPassword=********
 keyAlias=upload
 ```
 
-- `ios/fastlane/.env.default` : 아래와 같이 Apple ID 계정 정보를 입력합니다.
+### Credentials(iOS)
+- `ios/fastlane/.env.default` : 아래와 같이 본인의 Apple ID 계정 정보를 입력합니다.
 
 ```env
 FASTLANE_USER=****@****.***
@@ -59,6 +70,7 @@ apple_id("****@****.***") # Your Apple Developer Portal username
 itc_team_name("SPARCS") # App Store Connect Team Name
 team_id("N5V8W52U3U") # Developer Portal Team ID
 ```
+
 
 ### 알파 버전 배포
 

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -11,5 +11,5 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
-
 !ci.jks
+.env

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -46,9 +46,9 @@ platform :android do
       http_method: "POST",
       path: "/repos/sparcs-kaist/new-ara-app/releases",
       body: {
-        tag_name: "Android-v#{version_number}-#{version_code})",
+        tag_name: "Android-v#{version_number}-#{version_code}",
         target_commitish: current_commit_hash,
-        name: "Android-v#{version_number}-#{version_code})",
+        name: "Android-v#{version_number}-#{version_code}",
         body: "Write here the content of release notes...",
         draft: false,
         prerelease: false

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -8,6 +8,7 @@ platform :android do
     gradle(task: "test")
   end
 
+  
   desc "Set timestamp version from pubspec.yaml"
   lane :set_timestamp_version do
       yaml_file_path = "../../pubspec.yaml"
@@ -20,6 +21,40 @@ platform :android do
 
       data["version"] = new_version
       File.open(yaml_file_path, 'w') { |f| YAML.dump(data, f) }
+
+      # 새로운 버전 정보를 반환
+      {version: new_version, version_number: version_number, version_code: version_code}
+  end
+
+  desc "Create a release note on GitHub."
+  lane :create_release_note do
+
+
+    # YAML에서 버전 정보를 추출
+    yaml_file_path = "../../pubspec.yaml"
+    data = YAML.load_file(yaml_file_path)
+    version = data["version"]
+    version_number = data["version"].split("+")[0]
+    version_code = data["version"].split("+")[1]
+
+    # 현재 커밋 해시를 추출
+    current_commit_hash = `git rev-parse HEAD`.strip
+
+    # GitHub API를 사용하여 릴리즈 노트를 생성
+    # 릴리즈 노트에 태그 이름을 버전 정보로 설정
+    github_api(
+      http_method: "POST",
+      path: "/repos/sparcs-kaist/new-ara-app/releases",
+      body: {
+        tag_name: "Android-v#{version_number}-build.#{version_code}",
+        target_commitish: current_commit_hash,
+        name: "Android-v#{version_number}-build.#{version_code}",
+        body: "Here are the release notes...",
+        draft: false,
+        prerelease: false
+      }.to_json,
+      api_token: ENV["GITHUB_API_TOKEN"]
+    )
   end
 
   desc "Deploy a alpha version to the Google Play"
@@ -30,5 +65,6 @@ platform :android do
       aab: "../build/app/outputs/bundle/release/app-release.aab",
       track: "alpha",
     )
+    create_release_note
   end
 end

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -46,10 +46,10 @@ platform :android do
       http_method: "POST",
       path: "/repos/sparcs-kaist/new-ara-app/releases",
       body: {
-        tag_name: "Android-v#{version_number}-build.#{version_code}",
+        tag_name: "Android-v#{version_number}-#{version_code})",
         target_commitish: current_commit_hash,
-        name: "Android-v#{version_number}-build.#{version_code}",
-        body: "Here are the release notes...",
+        name: "Android-v#{version_number}-#{version_code})",
+        body: "Write here the content of release notes...",
         draft: false,
         prerelease: false
       }.to_json,

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -16,6 +16,37 @@
 default_platform(:ios)
 
 platform :ios do
+
+  desc "Create a release note on GitHub."
+  lane :create_release_note do
+    # YAML 파일에서 버전 정보를 로드
+    yaml_file_path = "../../pubspec.yaml"
+    data = YAML.load_file(yaml_file_path)
+    version = data["version"]
+    version_number = version.split("+")[0]
+
+    # increment_build_number에서 설정된 버전 코드를 가져옴
+    version_code = get_build_number(xcodeproj: "Runner.xcodeproj")
+
+    # 현재 커밋 해시를 추출
+    current_commit_hash = `git rev-parse HEAD`.strip
+
+    # GitHub API를 사용하여 릴리즈 노트를 생성
+    github_api(
+      http_method: "POST",
+      path: "/repos/sparcs-kaist/new-ara-app/releases",
+      body: {
+        tag_name: "iOS-v#{version_number}-#{version_code}",
+        target_commitish: current_commit_hash,
+        name: "iOS-v#{version_number}-#{version_code}",
+        body: "Write here the content of release notes...",
+        draft: false,
+        prerelease: false
+      }.to_json,
+      api_token: ENV["GITHUB_API_TOKEN"]
+    )
+  end
+
   desc "Push a new beta build to TestFlight"
   lane :alpha do
     increment_build_number(
@@ -41,5 +72,6 @@ platform :ios do
     upload_to_testflight(
       skip_waiting_for_build_processing: true,
     )
+    create_release_note
   end
 end

--- a/lib/constants/url_info.dart
+++ b/lib/constants/url_info.dart
@@ -1,4 +1,4 @@
 //const newAraDefaultUrl = "https://newara.dev.sparcs.org";
-const newAraDefaultUrl = "https://newara.dev.sparcs.org";
-const newAraAuthority = "newara.dev.sparcs.org";
+const newAraDefaultUrl = "https://newara.sparcs.org";
+const newAraAuthority = "newara.sparcs.org";
 const sparcsSSODefaultUrl = "https://sparcssso.kaist.ac.kr";


### PR DESCRIPTION
기존: 릴리즈 노트를 수동으로 적어야함.

변경: cd과정을 수정했습니다.
플레이스토어에 배포가 된 이후 자동으로 현재 버젼과 빌드 번호를 조합한 릴리즈 노트(태그)를 생성하도록 fastlane 코드를 수정했습니다.
배포 이후 자동으로 릴리즈 노트(태그)를 생성하면 유지 보수에 도움이 될 것이라고 생각합니다.

루비 코드와 api 공부했습니다. 이해 안되시는 것 있으면 질문 부탁드립니다.
맘에 드시면 ios에도 추가하도록 할게요.