### PR TITLE
PostListShowPage 게시판 리프레쉬 후 올바른 다음 페이지 게시물들이 불러와지지 않던 버그 수정

### DIFF
--- a/lib/pages/post_list_show_page.dart
+++ b/lib/pages/post_list_show_page.dart
@@ -110,7 +110,10 @@ class _PostListShowPageState extends State<PostListShowPage>
 
     // 모든 페이지를 순회하며 게시물 목록을 업데이트합니다.
     for (int page = 1;
-        page <= (pageLimitToReload != null ? min(pageLimitToReload, currentPage) : currentPage);
+        page <=
+            (pageLimitToReload != null
+                ? min(pageLimitToReload, currentPage)
+                : currentPage);
         page++) {
       Map<String, dynamic>? json = await userProvider.getApiRes("$apiUrl$page");
 
@@ -133,7 +136,9 @@ class _PostListShowPageState extends State<PostListShowPage>
     if (mounted) {
       setState(() {
         /// 현재 어디까지 로딩됐는 지 기록하는 변수 [currentPage]를 업데이트합니다.
-        currentPage = pageLimitToReload ?? currentPage;
+        currentPage = (pageLimitToReload != null
+            ? min(pageLimitToReload, currentPage)
+            : currentPage);
         postPreviewList.clear();
         postPreviewList.addAll(newList);
         isLoading = false; // 로딩 상태 업데이트

--- a/lib/pages/post_list_show_page.dart
+++ b/lib/pages/post_list_show_page.dart
@@ -33,7 +33,8 @@ class PostListShowPage extends StatefulWidget {
 class _PostListShowPageState extends State<PostListShowPage>
     with WidgetsBindingObserver {
   List<ArticleListActionModel> postPreviewList = [];
-  // 현재 어디까지 페이지가 로딩됐는 지 기록하는 변수
+
+  /// 현재 어디까지 페이지가 로딩됐는 지 기록하는 변수
   int currentPage = 1;
   bool isLoading = true;
   String apiUrl = "";
@@ -103,7 +104,8 @@ class _PostListShowPageState extends State<PostListShowPage>
 
   /// 게시물 update(게시판의 current페이지까지에 있는 게시물들을 불러옴)
   ///
-  /// [pageLimitToReload] : 새로 로딩할 최대 페이지 수
+  /// [pageLimitToReload] : 새로 로딩할 최대 페이지 수.
+  /// [currentPage] 값보다 [pageLimitToReload] 값이 큰 지 코딩할 때 주의 바랍니다.
   Future<void> updateAllBulletinList({int? pageLimitToReload}) async {
     List<ArticleListActionModel> newList = [];
     UserProvider userProvider = context.read<UserProvider>();
@@ -111,9 +113,8 @@ class _PostListShowPageState extends State<PostListShowPage>
     // 모든 페이지를 순회하며 게시물 목록을 업데이트합니다.
     for (int page = 1;
         page <=
-            (pageLimitToReload != null
-                ? min(pageLimitToReload, currentPage)
-                : currentPage);
+            // pageLimitToReload가 null이 아니면(파라미터가 존재하면) currentPage보다 우선시 합니다.
+            (pageLimitToReload ?? currentPage);
         page++) {
       Map<String, dynamic>? json = await userProvider.getApiRes("$apiUrl$page");
 
@@ -136,9 +137,7 @@ class _PostListShowPageState extends State<PostListShowPage>
     if (mounted) {
       setState(() {
         /// 현재 어디까지 로딩됐는 지 기록하는 변수 [currentPage]를 업데이트합니다.
-        currentPage = (pageLimitToReload != null
-            ? min(pageLimitToReload, currentPage)
-            : currentPage);
+        currentPage = (pageLimitToReload ?? currentPage);
         postPreviewList.clear();
         postPreviewList.addAll(newList);
         isLoading = false; // 로딩 상태 업데이트

--- a/lib/pages/post_list_show_page.dart
+++ b/lib/pages/post_list_show_page.dart
@@ -33,6 +33,7 @@ class PostListShowPage extends StatefulWidget {
 class _PostListShowPageState extends State<PostListShowPage>
     with WidgetsBindingObserver {
   List<ArticleListActionModel> postPreviewList = [];
+  // 현재 어디까지 페이지가 로딩됐는 지 기록하는 변수
   int currentPage = 1;
   bool isLoading = true;
   String apiUrl = "";
@@ -102,14 +103,14 @@ class _PostListShowPageState extends State<PostListShowPage>
 
   /// 게시물 update(게시판의 current페이지까지에 있는 게시물들을 불러옴)
   ///
-  /// [maxPage] : 새로 로딩할 최대 페이지 수
-  Future<void> updateAllBulletinList({int? maxPage}) async {
+  /// [pageLimitToReload] : 새로 로딩할 최대 페이지 수
+  Future<void> updateAllBulletinList({int? pageLimitToReload}) async {
     List<ArticleListActionModel> newList = [];
     UserProvider userProvider = context.read<UserProvider>();
 
     // 모든 페이지를 순회하며 게시물 목록을 업데이트합니다.
     for (int page = 1;
-        page <= (maxPage != null ? min(maxPage, currentPage) : currentPage);
+        page <= (pageLimitToReload != null ? min(pageLimitToReload, currentPage) : currentPage);
         page++) {
       Map<String, dynamic>? json = await userProvider.getApiRes("$apiUrl$page");
 
@@ -131,6 +132,8 @@ class _PostListShowPageState extends State<PostListShowPage>
     // 위젯이 마운트 상태인 경우 상태를 업데이트합니다.
     if (mounted) {
       setState(() {
+        /// 현재 어디까지 로딩됐는 지 기록하는 변수 [currentPage]를 업데이트합니다.
+        currentPage = pageLimitToReload ?? currentPage;
         postPreviewList.clear();
         postPreviewList.addAll(newList);
         isLoading = false; // 로딩 상태 업데이트
@@ -293,7 +296,7 @@ class _PostListShowPageState extends State<PostListShowPage>
                     color: ColorsInfo.newara,
                     onRefresh: () async {
                       setState((() => isLoading = true));
-                      await updateAllBulletinList(maxPage: 1);
+                      await updateAllBulletinList(pageLimitToReload: 1);
                     },
                     child: ListView.separated(
                       physics: const AlwaysScrollableScrollPhysics(),

--- a/lib/pages/post_write_page.dart
+++ b/lib/pages/post_write_page.dart
@@ -497,7 +497,8 @@ class _PostWritePageState extends State<PostWritePage>
                       isUpdate: true,
                       previousArticleId: widget.previousArticle!.id)
                   : _managePost())
-              : () => showInfoBySnackBar(context, "게시판을 선택해주시고 제목, 내용을 입력해주세요."),
+              : () =>
+                  showInfoBySnackBar(context, "게시판을 선택해주시고 제목, 내용을 입력해주세요."),
           // 버튼이 클릭되었을 때 수행할 동작
           padding: EdgeInsets.zero, // 패딩 제거
           child: canIupload
@@ -1259,7 +1260,10 @@ class _PostWritePageState extends State<PostWritePage>
               customButtons: [
                 quill.QuillCustomButton(
                   icon: Icons.camera_alt,
-                  onTap: _pickImage,
+                  onTap: () async {
+                    await _pickImage();
+                    _onTextChanged();
+                  },
                 ),
               ],
               // embedButtons: FlutterQuillEmbeds.buttons(),


### PR DESCRIPTION
 **다음 페이지의 게시물들이 로드 되지 않던 버그 수정**

기존: 게시물 목록 끝까지 갔다가 게시판을 새로고침한 후, 아래로 스크롤을 내리면 다음 페이지의 게시물들이 로드 되지 않던 문제 발생

원인: pageLimitToReload( 다시 어디까지 로딩되는 페이지)를 지정하고, 현재 페이지(currentPage)를 초기화 안함.
초기화를 안하면 currentPage가 (최대 페이지 +1) 이라 올바른 페이지가 로딩이 안됨.

변경: pageLimitToReload 사용 시 pageLimitToReload를 maxPage로 변경