### PR TITLE
dev/modify fastlane githubaction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [dev, main]
   pull_request:
-    branches: [dev]
+    branches: [dev, main]
 
 env:
   FLUTTER_VERSION: "3.13"
@@ -34,6 +34,10 @@ jobs:
           echo "keyAlias=ci" >> android/key.properties
       - name: Install dependencies
         run: flutter pub get
+      - name: Create .env files
+        run: |
+          echo "${{ secrets.ENV_PRODUCTION_FILE_CONTENT }}" > .env.production
+          echo "${{ secrets.ENV_DEVELOPMENT_FILE_CONTENT }}" > .env.development
       - name: Build APK
         run: flutter build apk --release --no-tree-shake-icons
 
@@ -57,5 +61,9 @@ jobs:
             ${{ runner.os }}-pods-
       - name: Install dependencies
         run: flutter pub get
+      - name: Create .env files
+        run: |
+          echo "${{ secrets.ENV_PRODUCTION_FILE_CONTENT }}" > .env.production
+          echo "${{ secrets.ENV_DEVELOPMENT_FILE_CONTENT }}" > .env.development
       - name: Build iOS
         run: flutter build ios --release --no-codesign --no-tree-shake-icons

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ ios/fastlane/README.md
 ios/fastlane/.env.default
 ios/Runner.app.dSYM.zip
 ios/Runner.ipa
+
+.env
+.env.development
+.env.production

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,7 @@
 # 기여하기
 
-아래 내용은 추후 README.md로 옮겨야함.
-
-## Release 절차(~ 2024.02.24 )
+---
+## How to release( ~ 2024.02.24 )
 
 1. [Releases](https://github.com/sparcs-kaist/new-ara-app/releases)에 갑니다.
 2. 이번 버전에서 변경된 사항을 Changes에 작성합니다.드래프트로 올립니다.
@@ -13,12 +12,13 @@
 ~~버전을 하나 올린 후 `flutter build ios`를 반드시 실행해 주도록 합니다~~
 ios FastFile에 `sh "flutter build ios --release --no-codesign --no-tree-shake-icons"` 추가해서 fastlane시 항상 자동으로 빌드하도록 수정했습니다.
 
-## Release 절차( 2024.02.25 ~)
-릴리즈 노트를 자동으로 작성하는 cd 코드를 main 브랜치에 추가했습니다.
+## How to release( 2024.02.25 ~ )
+릴리즈 노트를 자동으로 작성하는 cd 코드를 추가했습니다.
 1. `pubspec.yaml`의 버전을 하나 올리는 커밋을 원격 저장소에 Pull Request하고 Merge 합니다.
-2. fastlane으로 Android와 iOS에 deploy를 합니다.
+2. 아래 How to deploy 항목을 보고 Android와 iOS에 deploy를 합니다.
 3. [Releases](https://github.com/sparcs-kaist/new-ara-app/releases) 페이지에서 자동으로 등록된 릴리즈 노트의 내용을 수정합니다.
 
+---
 ## How to deploy
 
 ### Fastlane 설정
@@ -49,7 +49,7 @@ bundle install
 ```env
 GITHUB_API_TOKEN=****************************************
 ```
-GITHUB_API_TOKEN 발급 받는 법: https://lifefun.tistory.com/161
+[GITHUB_API_TOKEN 발급 받는 법](https://lifefun.tistory.com/161)
 
 
 - `android/key.properties` : 아래와 같이 Signing Key 정보를 입력합니다.
@@ -71,7 +71,7 @@ FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=****-****-****-****
 GITHUB_API_TOKEN=****************************************
 ```
 
-- `ios/fastlane/Appfile` : 아래와 같이 Apple ID 계정 정보를 입력합니다.
+- `ios/fastlane/Appfile` : 아래와 같이 Applefile이 되어있나 확인합니다.
 ```env
 app_identifier("org.sparcs.new-ara-app") # The bundle identifier of your app
 apple_id(ENV["FASTLANE_USER"]) # It automatically references .env.deault file
@@ -84,7 +84,7 @@ team_id("N5V8W52U3U") # Developer Portal Team ID
 ### 알파 버전 배포
 
 - Android: Google Play 스토어 `비공개 테스트 - Alpha` 트랙으로 업로드
-- iOS: TestFlight로 업로드
+- iOS: `TestFlight`로 업로드
 
 
 **앱에서 배포 서버는 production을 기본으로 합니다**
@@ -110,4 +110,3 @@ cd ios && bundle exec fastlane alpha env:development
 ### 배포 후 작업
 - `pubspec.yaml` 변경 사항을 Discard 합니다.
 - iOS Xcode 프로젝트 관련 파일들( `ios/Runner.xcodeproj/project.pbxproj`, `ios/Runner/Info.plist` )의 변경사항을 Discard 합니다.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # 기여하기
 
+아래 내용은 추후 README.md로 옮겨야함.
+
 ## Release 절차(~ 2024.02.24 )
 
 1. [Releases](https://github.com/sparcs-kaist/new-ara-app/releases)에 갑니다.
@@ -72,7 +74,7 @@ GITHUB_API_TOKEN=****************************************
 - `ios/fastlane/Appfile` : 아래와 같이 Apple ID 계정 정보를 입력합니다.
 ```env
 app_identifier("org.sparcs.new-ara-app") # The bundle identifier of your app
-apple_id("****@****.***") # Your Apple Developer Portal username
+apple_id(ENV["FASTLANE_USER"]) # It automatically references .env.deault file
 
 itc_team_name("SPARCS") # App Store Connect Team Name
 team_id("N5V8W52U3U") # Developer Portal Team ID
@@ -84,19 +86,25 @@ team_id("N5V8W52U3U") # Developer Portal Team ID
 - Android: Google Play 스토어 `비공개 테스트 - Alpha` 트랙으로 업로드
 - iOS: TestFlight로 업로드
 
-아래 명령어 시 `pubspec.yaml`에 있는 버젼 정보와 현재 시각으로 지정된 빌드 정보 기준으로 업로드 됩니다.
 
-**앱에서 백엔드 대상이 prod가 맞는지 배포 전 꼭 확인 하세요!**
+**앱에서 배포 서버는 production을 기본으로 합니다**
+프로젝트 루트 디렉토리에서 아래 명령어 시 `pubspec.yaml`에 있는 버젼 정보와 현재 시각으로 지정된 빌드 정보 기준으로 업로드 됩니다.
 
 ```bash
-cd android && bundle exec fastlane alpha && cd ../ios && bundle exec fastlane alpha
+cd android && bundle exec fastlane alpha env:production && cd ../ios && bundle exec fastlane alpha env:production
 ```
 
 
 아래 예시처럼 하나의 플랫폼에도 배포가 가능합니다.
 
 ```bash
-cd ios && bundle exec fastlane alpha
+cd ios && bundle exec fastlane alpha env:production
+```
+
+아래 예시처럼 dev 서버와 연결된 앱 배포도 가능합니다.
+
+```bash
+cd ios && bundle exec fastlane alpha env:development
 ```
 
 ### 배포 후 작업

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align=center>
   <a href="https://newara.sparcs.org">
     <img
-      src="https://raw.githubusercontent.com/sparcs-kaist/new-ara-web/master/src/assets/Services-Ara.png"
+      src="https://raw.githubusercontent.com/sparcs-kaist/new-ara-app/dev/assets/images/logo.svg"
       alt="Ara Logo"
       height="150"
     >
@@ -26,3 +26,30 @@
     />
   </a>
 </p>
+
+## How to develop
+### run
+
+`FLUTTER_VERSION: "3.13"`, `JAVA_VERSION: "11"`
+
+
+- `.env.development` : 프로젝트 루트 디렉토리에 `.env.developemnt` 파일을 생성하고 아래와 같이 정보를 입력합니다.
+```env
+NEW_ARA_DEFAULT_URL=https://newara.dev.sparcs.org
+NEW_ARA_AUTHORITY=newara.dev.sparcs.org
+SPARCS_SSO_DEFAULT_URL=https://sparcssso.kaist.ac.kr
+```
+<br>
+
+- `.env.production` : 프로젝트 루트 디렉토리에 `.env.production` 파일을 생성하고 아래와 같이 정보를 입력합니다.
+```env
+NEW_ARA_DEFAULT_URL=https://newara.sparcs.org
+NEW_ARA_AUTHORITY=newara.sparcs.org
+SPARCS_SSO_DEFAULT_URL=https://sparcssso.kaist.ac.kr
+```
+
+<br>
+
+- `development`와 `production` 둘 중 하나를 선택해서 실행합니다.
+ex) `flutter run --dart-define=ENV=development`
+ex) `flutter run --dart-define=ENV=production`

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -27,7 +27,7 @@ platform :android do
   end
 
   desc "Create a release note on GitHub."
-  lane :create_release_note do
+  lane :create_release_note do |options|
 
 
     # YAML에서 버전 정보를 추출
@@ -46,9 +46,9 @@ platform :android do
       http_method: "POST",
       path: "/repos/sparcs-kaist/new-ara-app/releases",
       body: {
-        tag_name: "Android-v#{version_number}-#{version_code}",
+        tag_name: "Android-v#{version_number}-#{version_code}-#{options[:short_name]}",
         target_commitish: current_commit_hash,
-        name: "Android-v#{version_number}-#{version_code}",
+        name: "Android-v#{version_number}-#{version_code}-#{options[:short_name]}",
         body: "Write here the content of release notes...",
         draft: false,
         prerelease: false
@@ -58,13 +58,30 @@ platform :android do
   end
 
   desc "Deploy a alpha version to the Google Play"
-  lane :alpha do
+  lane :alpha do |options|
+    unless ["production", "development"].include?(options[:env])
+      UI.user_error!("Invalid env given, pass using `env: 'production'` or `env: 'development'`")
+    end
+
+    short_name = ""
+    long_name = ""
+
+    if(options[:env] == "production")
+      # 배포용
+      short_name = "prod"
+      long_name = "production"
+    else
+      # 개발용
+      short_name = "dev"
+      long_name = "development"
+    end
+
     set_timestamp_version
-    sh "flutter build appbundle --no-tree-shake-icons"
+    sh "flutter build appbundle --no-tree-shake-icons --dart-define=ENV=#{long_name}"
     upload_to_play_store(
       aab: "../build/app/outputs/bundle/release/app-release.aab",
       track: "alpha",
     )
-    create_release_note
+    create_release_note(short_name: short_name)
   end
 end

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,5 +1,5 @@
 app_identifier("org.sparcs.new-ara-app") # The bundle identifier of your app
-apple_id(ENV["FASTLANE_USER"]) # Your Apple Developer Portal username
+apple_id(ENV["FASTLANE_USER"]) # It automatically references .env.deault file
 
 itc_team_name("SPARCS") # App Store Connect Team Name
 team_id("N5V8W52U3U") # Developer Portal Team ID

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,5 +1,5 @@
 app_identifier("org.sparcs.new-ara-app") # The bundle identifier of your app
-apple_id("tkddh1109@gmail.com") # Your Apple Developer Portal username
+apple_id(ENV["FASTLANE_USER"]) # Your Apple Developer Portal username
 
 itc_team_name("SPARCS") # App Store Connect Team Name
 team_id("N5V8W52U3U") # Developer Portal Team ID

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -18,7 +18,7 @@ default_platform(:ios)
 platform :ios do
 
   desc "Create a release note on GitHub."
-  lane :create_release_note do
+  lane :create_release_note do |options|
     # YAML 파일에서 버전 정보를 로드
     yaml_file_path = "../../pubspec.yaml"
     data = YAML.load_file(yaml_file_path)
@@ -36,9 +36,9 @@ platform :ios do
       http_method: "POST",
       path: "/repos/sparcs-kaist/new-ara-app/releases",
       body: {
-        tag_name: "iOS-v#{version_number}-#{version_code}",
+        tag_name: "iOS-v#{version_number}-#{version_code}-#{options[:short_name]}",
         target_commitish: current_commit_hash,
-        name: "iOS-v#{version_number}-#{version_code}",
+        name: "iOS-v#{version_number}-#{version_code}-#{options[:short_name]}",
         body: "Write here the content of release notes...",
         draft: false,
         prerelease: false
@@ -48,7 +48,24 @@ platform :ios do
   end
 
   desc "Push a new beta build to TestFlight"
-  lane :alpha do
+  lane :alpha do |options|
+    unless ["production", "development"].include?(options[:env])
+      UI.user_error!("Invalid env given, pass using `env: 'production'` or `env: 'development'`")
+    end
+
+    short_name = ""
+    long_name = ""
+
+    if(options[:env] == "production")
+      # 배포용
+      short_name = "prod"
+      long_name = "production"
+    else
+      # 개발용
+      short_name = "dev"
+      long_name = "development"
+    end
+
     increment_build_number(
       build_number: Time.now.strftime("%y%m%d.%H%M"),
       xcodeproj: "Runner.xcodeproj",
@@ -61,7 +78,7 @@ platform :ios do
     )
 
     #버젼 변경할 때마다 빌드해야하는 번거로움을 줄이기 위해서 코드 추가
-    sh "flutter build ios --release --no-codesign --no-tree-shake-icons"
+    sh "flutter build ios --release --no-codesign --no-tree-shake-icons --dart-define=ENV=#{long_name}"
 
     build_app(
       workspace: "Runner.xcworkspace",
@@ -72,6 +89,6 @@ platform :ios do
     upload_to_testflight(
       skip_waiting_for_build_processing: true,
     )
-    create_release_note
+    create_release_note(short_name: short_name)
   end
 end

--- a/lib/constants/url_info.dart
+++ b/lib/constants/url_info.dart
@@ -1,4 +1,3 @@
-//const newAraDefaultUrl = "https://newara.dev.sparcs.org";
-const newAraDefaultUrl = "https://newara.dev.sparcs.org";
-const newAraAuthority = "newara.dev.sparcs.org";
-const sparcsSSODefaultUrl = "https://sparcssso.kaist.ac.kr";
+late final String newAraDefaultUrl;
+late final String newAraAuthority;
+late final String sparcsSSODefaultUrl;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:new_ara_app/constants/url_info.dart';
 import 'package:new_ara_app/pages/terms_and_conditions_page.dart';
 import 'package:new_ara_app/widgets/loading_indicator.dart';
 import 'package:provider/provider.dart';
@@ -22,6 +24,18 @@ void main() async {
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   await EasyLocalization.ensureInitialized();
+
+
+  // .env.delevopment 또는 .env.production 파일을 읽어서 환경변수 설정
+  // ex) flutter run --dart-define=ENV=development
+  // ex) flutter run --dart-define=ENV=production
+  const String environment =
+      String.fromEnvironment('ENV', defaultValue: 'development');
+  await dotenv.load(fileName: ".env.$environment");
+
+  newAraDefaultUrl = dotenv.env['NEW_ARA_DEFAULT_URL']!;
+  newAraAuthority = dotenv.env['NEW_ARA_AUTHORITY']!;
+  sparcsSSODefaultUrl = dotenv.env['SPARCS_SSO_DEFAULT_URL']!;
 
   // 앱 시작점. 다국어 지원 및 여러 데이터 제공자를 포함한 구조로 설정
   runApp(
@@ -71,6 +85,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+
     // 자동 로그인을 위한 초기 설정
     autoLoginByGetCookie(Provider.of<UserProvider>(context, listen: false));
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -310,6 +310,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: "9357883bdd153ab78cbf9ffa07656e336b8bbb2b5a3ca596b0b27e119f7c7d77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   flutter_driver:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   shared_preferences: "^2.2.2"
   file_icon: "^1.0.0"
   flutter_native_splash: "^2.3.7"
+  flutter_dotenv: ^5.1.0
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -54,6 +55,8 @@ flutter:
   - assets/translations/
   - assets/images/
   - assets/icons/
+  - .env.development
+  - .env.production
   fonts:
   - family: NotoSansKR
     fonts:


### PR DESCRIPTION
### github action 수정으로 CI 과정 수정
- `sangohkim`과 `skykhs3` 레포 owner 권한으로 승급
- `repo secrets`에 `.env.development`, `.env.production` 추가
- `github action build` 시 `repo secretes` 참조하여 build 테스트

### fastlane 수정으로 CD 과정 수정
- 실행 예시 
`cd android && bundle exec fastlane alpha env:production && cd ../ios && bundle exec fastlane alpha env:production`
`cd android && bundle exec fastlane alpha env:development && cd ../ios && bundle exec fastlane alpha env:development`
fastlane 실행 시 무슨 환경에서 실행하는 지 파라미터를 추가해서 dev 서버가 배포되는 실수 방지.

### flutter run 방법 변경
- 실행 예시
`flutter run --dart-define=ENV=development`
`flutter run --dart-define=ENV=production`

### TODO
- 레포 시크릿 관리 방법에 대한 내용을 CONTRIBUTE.md에 추가해야함
