### PR TITLE
Feat: Implementing a method that prevents Google Examiner from writing comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,7 @@ team_id("N5V8W52U3U") # Developer Portal Team ID
 cd android && bundle exec fastlane alpha env:production && cd ../ios && bundle exec fastlane alpha env:production
 ```
 
+<br>
 
 아래 예시처럼 하나의 플랫폼에도 배포가 가능합니다.
 
@@ -104,10 +105,18 @@ cd android && bundle exec fastlane alpha env:production && cd ../ios && bundle e
 cd ios && bundle exec fastlane alpha env:production
 ```
 
+<br>
+
 아래 예시처럼 dev 서버와 연결된 앱 배포도 가능합니다.
 
 ```bash
 cd ios && bundle exec fastlane alpha env:development
+```
+<br>
+
+아래 예시처럼 개별 fastlane 실행도 가능합니다. 아래는 깃허브 태그를 만드는 fastlane입니다.
+```base
+bundle exec fastlane create_release_note short_name:prod
 ```
 
 ### 배포 후 작업

--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -311,7 +311,8 @@ class _PostViewPageState extends State<PostViewPage> {
                                                   const BorderRadius.all(
                                                       Radius.circular(10)),
                                               border: Border.all(
-                                                  color: const Color(0xFFDBDBDB),
+                                                  color:
+                                                      const Color(0xFFDBDBDB),
                                                   width: 1),
                                               boxShadow: const [
                                                 BoxShadow(
@@ -1732,6 +1733,23 @@ class _PostViewPageState extends State<PostViewPage> {
                 absorbing: _isSending,
                 child: InkWell(
                   onTap: () async {
+                    debugPrint("post_view_page.dart: Send Comment");
+                    if (Platform.isAndroid &&
+                        (userProvider.naUser!.email != null &&
+                            userProvider.naUser!.email ==
+                                "tkddh1109@gmail.com")) {
+                      await showDialog(
+                          builder: (context) => ForAndroidTesterDialog(
+                                userProvider: userProvider,
+                                targetContext: context,
+                                onTap: () {
+                                  Navigator.pop(context);
+                                },
+                              ),
+                          context: context);
+
+                      return;
+                    }
                     _setIsSending(true);
                     bool sendRes = await _sendComment(userProvider);
                     if (sendRes) {

--- a/lib/widgets/dialogs.dart
+++ b/lib/widgets/dialogs.dart
@@ -991,19 +991,19 @@ class ForAndroidTesterDialog extends StatelessWidget {
                         controller: _scrollController,
                         children: const [
                           Text(
-                            '''I hope this message finds you well. I am writing to seek assistance regarding an issue we've encountered following the submission of our app to the Google Play Store, specifically on the public track for review.
-                            
-We have observed an unusual volume of comments within our app, which seems to be related to the review process. This has led to significant inconvenience for our users, particularly impacting the user experience for students who rely on our app for communication and educational purposes.,
-                          
-While we understand the importance of thorough app reviews and user feedback, we believe there might be a misunderstanding or a technical issue that has resulted in excessive commenting. This has not only affected the app's performance but also its reception among our target audience.
-                          
+                            '''I am writing to seek assistance regarding an issue we have encountered following the production review of our app on the Google Play Store.
+
+During our production review process, we observed an unusual volume of comments within our app, which appear to be related to the review process itself. These abnormal comments were made using an account provided exclusively to Google Play Store reviewers. This situation has caused significant inconvenience, especially for students who rely on our app for communication and educational purposes.
+
+While we understand the importance of thorough app reviews and user feedback, we suspect that a misunderstanding or a technical issue has led to the excessive commenting. This not only affects the app's performance but also its acceptance among our target audience.
+
 To resolve this issue, we would greatly appreciate it if you could provide guidelines on why comment posting is necessary during the review process and what features we should demonstrate. Our goal is to ensure a positive and constructive environment for our users while adhering to Google Play's policies and standards.
-                          
-We appreciate your understanding and assistance in this matter. Please let us know if there are specific steps we should follow or if additional information is required from our side.
-                          
-Thank you for your attention to this issue. We look forward to your prompt response and support.
-                          
-Best regards,
+
+We are thankful for your understanding and support on this matter. Please let us know if there are specific procedures we should follow or if additional information is required from our side.
+
+Thank you for your attention and support on this issue. We look forward to your prompt response.
+
+Sincerely,
 
 
 안녕하십니까? 구글 플레이 스토어의 프로덕션 심사 후 저희가 마주한 문제에 대해 도움을 요청하기 위해 이 메시지를 작성합니다.

--- a/lib/widgets/dialogs.dart
+++ b/lib/widgets/dialogs.dart
@@ -73,16 +73,13 @@ class _ReportDialogState extends State<ReportDialog> {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            SvgPicture.asset(
-              "assets/icons/information.svg",
-              width: 45,
-              height: 45,
-              colorFilter: const ColorFilter.mode(
-                ColorsInfo.newara,
-                BlendMode.srcIn,
-              )
-        
-            ),
+            SvgPicture.asset("assets/icons/information.svg",
+                width: 45,
+                height: 45,
+                colorFilter: const ColorFilter.mode(
+                  ColorsInfo.newara,
+                  BlendMode.srcIn,
+                )),
             const SizedBox(height: 5),
             Text(
               '${widget.articleID == null ? '댓글' : '게시글'} 신고 사유를 알려주세요.',
@@ -742,7 +739,6 @@ class SignoutConfirmDialog extends StatelessWidget {
                 color: Colors.black,
               ),
             ),
-            
             const SizedBox(height: 20),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -924,6 +920,165 @@ class UnregisterConfirmDialog extends StatelessWidget {
               ],
             )
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class ForAndroidTesterDialog extends StatelessWidget {
+  final UserProvider userProvider;
+  final _scrollController = ScrollController();
+
+  /// PostViewPage의 context.
+  final BuildContext targetContext;
+
+  /// '확인' 버튼을 눌렀을 때 적용되는 onTap 메서드
+  final void Function()? onTap;
+
+  ForAndroidTesterDialog({
+    super.key,
+    required this.userProvider,
+    required this.targetContext,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: Container(
+        decoration: const BoxDecoration(
+          borderRadius: BorderRadius.all(Radius.circular(15)),
+        ),
+        child: SizedBox(
+          width: 350,
+          height: 500,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SvgPicture.asset(
+                'assets/icons/information.svg',
+                width: 55,
+                height: 55,
+                colorFilter: const ColorFilter.mode(
+                  ColorsInfo.newara,
+                  BlendMode.srcIn,
+                ),
+              ),
+              const Text(
+                'Dear Google Play Review Team,',
+                style: TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.black,
+                ),
+              ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    30,
+                    10,
+                    20,
+                    10,
+                  ),
+                  child: Scrollbar(
+                    thumbVisibility: true,
+                    controller: _scrollController,
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 10),
+                      child: ListView(
+                        controller: _scrollController,
+                        children: const [
+                          Text(
+                            '''I hope this message finds you well. I am writing to seek assistance regarding an issue we've encountered following the submission of our app to the Google Play Store, specifically on the public track for review.
+                            
+We have observed an unusual volume of comments within our app, which seems to be related to the review process. This has led to significant inconvenience for our users, particularly impacting the user experience for students who rely on our app for communication and educational purposes.,
+                          
+While we understand the importance of thorough app reviews and user feedback, we believe there might be a misunderstanding or a technical issue that has resulted in excessive commenting. This has not only affected the app's performance but also its reception among our target audience.
+                          
+To resolve this issue, we would greatly appreciate it if you could provide guidelines on why comment posting is necessary during the review process and what features we should demonstrate. Our goal is to ensure a positive and constructive environment for our users while adhering to Google Play's policies and standards.
+                          
+We appreciate your understanding and assistance in this matter. Please let us know if there are specific steps we should follow or if additional information is required from our side.
+                          
+Thank you for your attention to this issue. We look forward to your prompt response and support.
+                          
+Best regards,
+
+
+안녕하십니까? 구글 플레이 스토어의 프로덕션 심사 후 저희가 마주한 문제에 대해 도움을 요청하기 위해 이 메시지를 작성합니다.
+
+저희 프로덕션 심사 과정 중, 앱 내에서 심사 과정과 관련된 것으로 보이는 비정상적인 댓글 양을 관찰했습니다. 이 비정상적인 댓글은 구글 플레이 스토어 심사관에게만 제공한 계정을 통해 작성되었습니다. 이는 특히 저희 앱을 소통과 교육 목적으로 의존하는 학생들의 사용자 경험에 큰 불편을 초래하고 있습니다.
+
+철저한 앱 리뷰와 사용자 피드백의 중요성을 이해하고 있지만, 과도한 댓글이 발생한 배경에는 오해나 기술적 문제가 있을 것으로 생각합니다. 이는 앱의 성능뿐만 아니라 저희 타겟 오디언스 사이에서의 수용성에도 영향을 미치고 있습니다.
+
+이 문제를 해결하기 위해, 심사 과정 중 앱 내에서 댓글 작성이 필요한 이유와 저희가 어떤 기능을 보여줘야 하는지에 대한 가이드라인을 제시해주시면 감사하겠습니다. 저희의 목표는 구글 플레이의 정책과 기준을 준수하면서 사용자에게 긍정적이고 건설적인 환경을 보장하는 것입니다.
+
+이 문제에 대한 이해와 지원에 감사드립니다. 저희가 따라야 할 특정한 절차가 있거나 저희 측에서 추가 정보가 필요한 경우 알려주시기 바랍니다.
+
+이 문제에 주목해주시고 지원해주셔서 감사합니다. 신속한 답변과 지원을 기대합니다.
+
+감사합니다,  
+
+Google Playストアでのアプリのプロダクションレビュー後に遭遇した問題について支援を求めています。
+
+プロダクションレビュープロセス中に、レビュープロセス自体に関連していると思われるアプリ内での異常なコメントの量を観察しました。これらの異常なコメントは、Google Playストアのレビュアーにのみ提供されたアカウントを使用して作成されました。この状況は、通信および教育目的で私たちのアプリに依存している学生を含むユーザーにとって、大きな不便を引き起こしています。
+
+徹底的なアプリレビューとユーザーフィードバックの重要性を理解していますが、過剰なコメントにつながった誤解または技術的な問題があると疑っています。これは、アプリのパフォーマンスだけでなく、ターゲットオーディエンスの間での受け入れにも影響を与えています。
+
+この問題を解決するために、レビュープロセス中にコメント投稿が必要な理由と、私たちが示すべき機能についてのガイドラインを提供していただければ幸いです。私たちの目標は、Google Playのポリシーと基準を遵守しながら、ユーザーにとって肯定的で建設的な環境を確保することです。
+
+この件に関するご理解とサポートに感謝します。特定の手順を踏むべきか、私たちの側から追加情報が必要かどうか教えてください。
+
+この問題に対するご注意とサポートに感謝します。迅速なご返答をお待ちしています。
+
+敬具、
+                            ''',
+                            style: TextStyle(
+                              fontSize: 15,
+                              fontWeight: FontWeight.w700,
+                              color: Color(0xFFBBBBBB),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  InkWell(
+                    // 인자로 전달받은 onTap 사용.
+                    onTap: onTap,
+                    child: Container(
+                      decoration: const BoxDecoration(
+                        borderRadius: BorderRadius.all(Radius.circular(20)),
+                        color: ColorsInfo.newara,
+                      ),
+                      width: 80,
+                      height: 40,
+                      child: const Center(
+                        child: Text(
+                          'Confirm',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(
+                height: 20,
+              )
+            ],
+          ),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 name: new_ara_app
 description: A new Flutter project.
 publish_to: none
-version: 1.1.0+102212113
+version: 1.1.0+103040304
 environment:
   sdk: ">=2.18.0 <3.0.0"
 dependencies:
@@ -41,13 +41,13 @@ dependencies:
   shared_preferences: "^2.2.2"
   file_icon: "^1.0.0"
   flutter_native_splash: "^2.3.7"
-  webview_flutter_android: ^3.15.0
-  webview_flutter_wkwebview: ^3.10.2
-  flutter_dotenv: ^5.1.0
+  webview_flutter_android: "^3.15.0"
+  webview_flutter_wkwebview: "^3.10.2"
+  flutter_dotenv: "^5.1.0"
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: "^3.0.1"
   flutter_driver:
     sdk: flutter
   test: any
@@ -57,8 +57,8 @@ flutter:
   - assets/translations/
   - assets/images/
   - assets/icons/
-  - .env.development
-  - .env.production
+  - ".env.development"
+  - ".env.production"
   fonts:
   - family: Pretendard
     fonts:


### PR DESCRIPTION
I've implemented a notice to PlayStore Reviewer.
Google Tester keeps leaving certain emails in the comments.

# Issue

<div align="center">
  <img src="https://github.com/user-attachments/assets/da5f30d2-8a1e-45d1-aa59-0b78fa572655" width="50%">
  <img src="https://github.com/user-attachments/assets/7625620d-5d62-44b0-92de-260b822277ca" width="50%">
  <img src="https://github.com/user-attachments/assets/ba3ef5ea-0b1f-477a-bdc6-6f69b63da810" width="50%">
  <img src="https://github.com/user-attachments/assets/fa60b99f-26be-4ab4-8261-2c78ab8a9997" width="50%">
  <img src="https://github.com/user-attachments/assets/fabfd4f8-2738-4993-803f-1152fa540ded" width="50%">
</div>

# Feature

https://github.com/sparcs-kaist/new-ara-app/assets/5186472/d96a8b1e-edb0-447e-b5a0-39c62354db3e
