### PR TITLE
익명글에서 작성자명이 '익명', '글쓴이'일 때 로케일 적용

### DIFF
--- a/lib/pages/post_view_page.dart
+++ b/lib/pages/post_view_page.dart
@@ -31,6 +31,7 @@ import 'package:new_ara_app/utils/profile_image.dart';
 import 'package:new_ara_app/widgets/snackbar_noti.dart';
 import 'package:new_ara_app/providers/blocked_provider.dart';
 import 'package:new_ara_app/utils/handle_hidden.dart';
+import 'package:new_ara_app/utils/handle_name.dart';
 
 // TODO: Dio 사용방식 createDioWithHeaders~ 로 변경하기
 
@@ -749,7 +750,10 @@ class _PostViewPageState extends State<PostViewPage> {
               constraints: BoxConstraints(
                   maxWidth: MediaQuery.of(context).size.width - 150),
               child: Text(
-                _article.created_by.profile.nickname.toString(),
+                getName(
+                    _article.name_type,
+                    _article.created_by.profile.nickname.toString(),
+                    context.locale),
                 style: const TextStyle(
                   fontSize: 14,
                   fontWeight: FontWeight.w500,
@@ -1376,8 +1380,7 @@ class _PostViewPageState extends State<PostViewPage> {
                                       MediaQuery.of(context).size.width - 250,
                                 ),
                                 child: Text(
-                                  curComment.created_by.profile.nickname
-                                      .toString(),
+                                  getName(curComment.name_type, curComment.created_by.profile.nickname.toString(), context.locale),
                                   style: const TextStyle(
                                     fontSize: 14,
                                     fontWeight: FontWeight.w500,

--- a/lib/pages/post_write_page.dart
+++ b/lib/pages/post_write_page.dart
@@ -418,6 +418,7 @@ class _PostWritePageState extends State<PostWritePage>
 
   @override
   Widget build(BuildContext context) {
+    debugPrint("BUILD invoked!!!");
     /// 게시물 업로드 가능한지 확인
     /// TODO: 업로드 로딩 인디케이터 추가하기
     bool canIupload = _titleController.text != '' &&

--- a/lib/pages/setting_page.dart
+++ b/lib/pages/setting_page.dart
@@ -374,7 +374,7 @@ class SettingPageState extends State<SettingPage> {
                                   slideRoute(
                                     const TermsAndConditionsPage(),
                                   ),
-                                );
+                                ).then((_) => setState(() {}));
                               },
                               child: Row(
                                 mainAxisAlignment:

--- a/lib/utils/handle_name.dart
+++ b/lib/utils/handle_name.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+/// 익명인 경우 '익명', '글쓴이'로 표기되는 닉네임을 로케일에 맞게 변경해준다.
+/// 익명(nameType == 2)이면서 nickname이 '익명', '글쓴이'이고 locale이 en인 경우를 제외하면
+/// 원래 nickname을 그대로 리턴한다.
+String getName(int? nameType, String nickname, Locale locale) {
+  String res = nickname;
+
+  // 익명이면서 로케일이 en인 경우 상황에 따라 nickname 변경.
+  if (nameType == 2 && locale == const Locale('en')) {
+    if (nickname == '익명') {
+      res = 'Anonymous';
+    }
+    else if (nickname == '글쓴이') {
+      res = 'Author';
+    }
+  }
+
+  return res;
+}

--- a/lib/widgets/post_preview.dart
+++ b/lib/widgets/post_preview.dart
@@ -9,6 +9,7 @@ import 'package:new_ara_app/utils/time_utils.dart';
 import 'package:new_ara_app/providers/blocked_provider.dart';
 import 'package:new_ara_app/utils/handle_hidden.dart';
 import 'package:provider/provider.dart';
+import 'package:new_ara_app/utils/handle_name.dart';
 
 class PostPreview extends StatefulWidget {
   final ArticleListActionModel model;
@@ -111,7 +112,7 @@ class _PostPreviewState extends State<PostPreview> {
               children: [
                 Flexible(
                   child: Text(
-                    widget.model.created_by.profile.nickname.toString(),
+                    getName(widget.model.name_type, widget.model.created_by.profile.nickname.toString(), context.locale),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: const TextStyle(


### PR DESCRIPTION
'익명', '글쓴이'에 대해 로케일을 적용했습니다.
또한 설정 페이지, 이용약관 페이지 내비게이션할 때 로케일 적용이 곧바로 되도록 setState 추가했습니다.