### PR TITLE
Fix: day를 minute으로 변경

### DIFF
--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -23,7 +23,7 @@ String getTime(String rawTime, Locale locale) {
         "${difference.inSeconds}${locale == const Locale('ko') ? "초 전" : " seconds ago"}";
   } else if (difference.inHours < 1) {
     time =
-        '${difference.inMinutes}${locale == const Locale('ko') ? "분 전" : " days ago"}';
+        '${difference.inMinutes}${locale == const Locale('ko') ? "분 전" : " minutes ago"}';
   } else if (date.year == now.year &&
       date.month == now.month &&
       date.day == now.day) {


### PR DESCRIPTION
"39분 전"과 같이 "~분 전" 표현이 "days ago"로 번역되어 있어 "minutes ago"로 수정함.