### PR TITLE
Feat(main_page.dart): Chagne displacement of RefreshIndicator to zero

### DIFF
--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -430,6 +430,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
                 _isLoading[11]
             ? const LoadingIndicator()
             : RefreshIndicator.adaptive(
+                displacement: 0.0,
                 color: ColorsInfo.newara,
                 onRefresh: () async {
                   //api를 호출 후 최신 데이터로 갱신


### PR DESCRIPTION
## Overview
MainPage의 RefreshIndicator displacement를 제거함.

## Changes

## Implementaion Method
RefreshIndicator() 위젯의 displacement 필드값을 0으로 변경.

## After Changes

## Related Issues

## Rollback Scenario

## TODO