### PR TITLE
PostListShowPage 말머리 필터 추가

### DIFF
--- a/lib/pages/post_list_show_page.dart
+++ b/lib/pages/post_list_show_page.dart
@@ -285,9 +285,7 @@ class _PostListShowPageState extends State<PostListShowPage>
               ),
               onPressed: () {},
               child: Text(
-                context.locale == const Locale('ko')
-                    ? "달성 전"
-                    : "Preparing",
+                context.locale == const Locale('ko') ? "달성 전" : "Preparing",
                 style: const TextStyle(
                   fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
                   color: Color.fromARGB(255, 101, 100, 100),
@@ -309,9 +307,7 @@ class _PostListShowPageState extends State<PostListShowPage>
               ),
               onPressed: () {},
               child: Text(
-                context.locale == const Locale('ko')
-                    ? "답변 완료"
-                    : "Completed",
+                context.locale == const Locale('ko') ? "답변 완료" : "Completed",
                 style: const TextStyle(
                   fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
                   color: Color.fromARGB(255, 101, 100, 100),
@@ -322,29 +318,28 @@ class _PostListShowPageState extends State<PostListShowPage>
     }
     return <Widget>[
           Container(
-          height: 35,
-          margin: const EdgeInsets.only(right: 15),
-          child: TextButton(
-              style: ButtonStyle(
-                overlayColor: MaterialStateProperty.all(Colors.transparent),
-                shape: MaterialStateProperty.all(
-                  RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
-                    side: const BorderSide(color: Color(0xFFBBBBBB), width: 1),
+            height: 35,
+            margin: const EdgeInsets.only(right: 15),
+            child: TextButton(
+                style: ButtonStyle(
+                  overlayColor: MaterialStateProperty.all(Colors.transparent),
+                  shape: MaterialStateProperty.all(
+                    RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30),
+                      side:
+                          const BorderSide(color: Color(0xFFBBBBBB), width: 1),
+                    ),
                   ),
                 ),
-              ),
-              onPressed: () {},
-              child: Text(
-                context.locale == const Locale('ko')
-                    ? "전체"
-                    : "Total",
-                style: const TextStyle(
-                  fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
-                  color: Color.fromARGB(255, 101, 100, 100),
-                ),
-              )),
-        )
+                onPressed: () {},
+                child: Text(
+                  context.locale == const Locale('ko') ? "전체" : "Total",
+                  style: const TextStyle(
+                    fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
+                    color: Color.fromARGB(255, 101, 100, 100),
+                  ),
+                )),
+          )
         ] +
         ret;
   }
@@ -471,7 +466,11 @@ class _PostListShowPageState extends State<PostListShowPage>
                           ),
                         ),
                       if (isTopicsFilterRequired)
-                        const Divider(),
+                        Container(
+                          margin: EdgeInsets.only(top: 5),
+                          height: 1,
+                          color: const Color(0xFFF0F0F0),
+                        ),
                       Expanded(
                         child: RefreshIndicator.adaptive(
                           displacement: 0.0,

--- a/lib/pages/post_list_show_page.dart
+++ b/lib/pages/post_list_show_page.dart
@@ -61,6 +61,7 @@ class _PostListShowPageState extends State<PostListShowPage>
       });
     }
     debugPrint("=========================");
+    // TODO: '학교에게 전합니다' 게시판의 말머리가 생길 경우 조건문 수정해야함.
     isTopicsFilterRequired = (widget.boardInfo != null &&
         (widget.boardInfo!.slug == 'with-school' ||
             widget.boardInfo!.topics.isNotEmpty));
@@ -237,6 +238,75 @@ class _PostListShowPageState extends State<PostListShowPage>
     }
   }
 
+  List<Widget> _buildTopicBoxes(
+      BuildContext context, BoardDetailActionModel model) {
+    late List<Widget> ret;
+    if (model.slug != 'with-school') {
+      ret = List<Widget>.generate(model.topics.length, (index) {
+        return Container(
+          height: 35,
+          decoration: BoxDecoration(
+              borderRadius: const BorderRadius.all(Radius.circular(30)),
+              border: Border.all(color: const Color(0xFFBBBBBB))),
+          margin: const EdgeInsets.only(right: 15),
+          padding: const EdgeInsets.all(3.5),
+          child: InkWell(
+              borderRadius: const BorderRadius.all(Radius.circular(30)),
+              onTap: () {},
+              child: Center(
+                  child: Text(
+                context.locale == const Locale('ko')
+                    ? model.topics[index].ko_name
+                    : model.topics[index].en_name,
+                style: const TextStyle(
+                  fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
+                ),
+              ))),
+        );
+      });
+    } else {
+      ret = [
+        Container(
+          decoration: const BoxDecoration(
+            borderRadius: BorderRadius.all(Radius.circular(20)),
+          ),
+          child: Text(
+            context.locale == const Locale('ko') ? "답변완료" : "Answered",
+          ),
+        ),
+        Container(
+          decoration: const BoxDecoration(
+            borderRadius: BorderRadius.all(Radius.circular(20)),
+          ),
+          child: Text(
+            context.locale == const Locale('ko') ? "달성 전" : "Preparing",
+          ),
+        )
+      ];
+    }
+    return <Widget>[
+          Container(
+            height: 35,
+            decoration: BoxDecoration(
+                borderRadius: const BorderRadius.all(Radius.circular(25)),
+                border: Border.all(color: const Color(0xFFBBBBBB))),
+            margin: const EdgeInsets.only(right: 15),
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            child: InkWell(
+                borderRadius: const BorderRadius.all(Radius.circular(30)),
+                onTap: () {},
+                child: Center(
+                    child: Text(
+                  context.locale == const Locale('ko') ? "전체" : "Total",
+                  style: const TextStyle(
+                    fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
+                  ),
+                ))),
+          )
+        ] +
+        ret;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -345,7 +415,19 @@ class _PostListShowPageState extends State<PostListShowPage>
                     children: [
                       // 말머리필터
                       if (isTopicsFilterRequired)
-                        SizedBox(height: 35, child: Placeholder()),
+                        SizedBox(
+                          width: MediaQuery.of(context).size.width - 18,
+                          height: 40,
+                          child: SingleChildScrollView(
+                            scrollDirection: Axis.horizontal,
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              // isTopicsFilterRequired가 true이면 boardInfo가 null이 아님이 보장됨.
+                              children:
+                                  _buildTopicBoxes(context, widget.boardInfo!),
+                            ),
+                          ),
+                        ),
                       Expanded(
                         child: RefreshIndicator.adaptive(
                           displacement: 0.0,

--- a/lib/pages/post_list_show_page.dart
+++ b/lib/pages/post_list_show_page.dart
@@ -245,64 +245,106 @@ class _PostListShowPageState extends State<PostListShowPage>
       ret = List<Widget>.generate(model.topics.length, (index) {
         return Container(
           height: 35,
-          decoration: BoxDecoration(
-              borderRadius: const BorderRadius.all(Radius.circular(30)),
-              border: Border.all(color: const Color(0xFFBBBBBB))),
           margin: const EdgeInsets.only(right: 15),
-          padding: const EdgeInsets.all(3.5),
-          child: InkWell(
-              borderRadius: const BorderRadius.all(Radius.circular(30)),
-              onTap: () {},
-              child: Center(
-                  child: Text(
+          child: TextButton(
+              style: ButtonStyle(
+                overlayColor: MaterialStateProperty.all(Colors.transparent),
+                shape: MaterialStateProperty.all(
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                    side: const BorderSide(color: Color(0xFFBBBBBB), width: 1),
+                  ),
+                ),
+              ),
+              onPressed: () {},
+              child: Text(
                 context.locale == const Locale('ko')
                     ? model.topics[index].ko_name
                     : model.topics[index].en_name,
                 style: const TextStyle(
                   fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
+                  color: Color.fromARGB(255, 101, 100, 100),
                 ),
-              ))),
+              )),
         );
       });
     } else {
       ret = [
         Container(
-          decoration: const BoxDecoration(
-            borderRadius: BorderRadius.all(Radius.circular(20)),
-          ),
-          child: Text(
-            context.locale == const Locale('ko') ? "답변완료" : "Answered",
-          ),
+          height: 35,
+          margin: const EdgeInsets.only(right: 15),
+          child: TextButton(
+              style: ButtonStyle(
+                overlayColor: MaterialStateProperty.all(Colors.transparent),
+                shape: MaterialStateProperty.all(
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                    side: const BorderSide(color: Color(0xFFBBBBBB), width: 1),
+                  ),
+                ),
+              ),
+              onPressed: () {},
+              child: Text(
+                context.locale == const Locale('ko')
+                    ? "달성 전"
+                    : "Preparing",
+                style: const TextStyle(
+                  fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
+                  color: Color.fromARGB(255, 101, 100, 100),
+                ),
+              )),
         ),
         Container(
-          decoration: const BoxDecoration(
-            borderRadius: BorderRadius.all(Radius.circular(20)),
-          ),
-          child: Text(
-            context.locale == const Locale('ko') ? "달성 전" : "Preparing",
-          ),
+          height: 35,
+          margin: const EdgeInsets.only(right: 15),
+          child: TextButton(
+              style: ButtonStyle(
+                overlayColor: MaterialStateProperty.all(Colors.transparent),
+                shape: MaterialStateProperty.all(
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                    side: const BorderSide(color: Color(0xFFBBBBBB), width: 1),
+                  ),
+                ),
+              ),
+              onPressed: () {},
+              child: Text(
+                context.locale == const Locale('ko')
+                    ? "답변 완료"
+                    : "Completed",
+                style: const TextStyle(
+                  fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
+                  color: Color.fromARGB(255, 101, 100, 100),
+                ),
+              )),
         )
       ];
     }
     return <Widget>[
           Container(
-            height: 35,
-            decoration: BoxDecoration(
-                borderRadius: const BorderRadius.all(Radius.circular(25)),
-                border: Border.all(color: const Color(0xFFBBBBBB))),
-            margin: const EdgeInsets.only(right: 15),
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            child: InkWell(
-                borderRadius: const BorderRadius.all(Radius.circular(30)),
-                onTap: () {},
-                child: Center(
-                    child: Text(
-                  context.locale == const Locale('ko') ? "전체" : "Total",
-                  style: const TextStyle(
-                    fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
+          height: 35,
+          margin: const EdgeInsets.only(right: 15),
+          child: TextButton(
+              style: ButtonStyle(
+                overlayColor: MaterialStateProperty.all(Colors.transparent),
+                shape: MaterialStateProperty.all(
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                    side: const BorderSide(color: Color(0xFFBBBBBB), width: 1),
                   ),
-                ))),
-          )
+                ),
+              ),
+              onPressed: () {},
+              child: Text(
+                context.locale == const Locale('ko')
+                    ? "전체"
+                    : "Total",
+                style: const TextStyle(
+                  fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
+                  color: Color.fromARGB(255, 101, 100, 100),
+                ),
+              )),
+        )
         ] +
         ret;
   }
@@ -417,7 +459,7 @@ class _PostListShowPageState extends State<PostListShowPage>
                       if (isTopicsFilterRequired)
                         SizedBox(
                           width: MediaQuery.of(context).size.width - 18,
-                          height: 40,
+                          height: 35,
                           child: SingleChildScrollView(
                             scrollDirection: Axis.horizontal,
                             child: Row(
@@ -428,6 +470,8 @@ class _PostListShowPageState extends State<PostListShowPage>
                             ),
                           ),
                         ),
+                      if (isTopicsFilterRequired)
+                        const Divider(),
                       Expanded(
                         child: RefreshIndicator.adaptive(
                           displacement: 0.0,

--- a/lib/pages/post_list_show_page.dart
+++ b/lib/pages/post_list_show_page.dart
@@ -234,12 +234,6 @@ class _PostListShowPageState extends State<PostListShowPage>
     }
   }
 
-  void Function() setCurrentFilterIndex(int index) {
-    return () {
-      return setState(() => currentFilter = index);
-    };
-  }
-
   Widget _buildTopicButton(String text, int index) {
     return Container(
       height: 35,

--- a/lib/pages/post_list_show_page.dart
+++ b/lib/pages/post_list_show_page.dart
@@ -17,6 +17,7 @@ import 'package:new_ara_app/pages/post_view_page.dart';
 import 'package:new_ara_app/utils/slide_routing.dart';
 import 'package:new_ara_app/providers/notification_provider.dart';
 import 'package:new_ara_app/widgets/pop_up_menu_buttons.dart';
+import 'package:new_ara_app/utils/with_school.dart';
 
 /// PostListShowPage는 게시물 목록를 나타내는 위젯.
 /// boardType에 따라 게시판의 종류를 판별하고, 특성화 된 위젯들을 활성화 비활성화 되도록 설계.
@@ -34,6 +35,10 @@ class PostListShowPage extends StatefulWidget {
 class _PostListShowPageState extends State<PostListShowPage>
     with WidgetsBindingObserver {
   List<ArticleListActionModel> postPreviewList = [];
+
+  /// 현재 선택된 말머리 필터의 인덱스를 나타냄.
+  /// 기본값은 전체(= 0)
+  int currentFilter = 0;
 
   /// 말머리 필터가 필요한 지 여부를 나타내는 변수
   /// 학교에게 전합니다 게시판 or BoardDetailActionModel의 topics가 isNotEmpty일 때 true
@@ -238,108 +243,68 @@ class _PostListShowPageState extends State<PostListShowPage>
     }
   }
 
+  void Function() setCurrentFilterIndex(int index) {
+    return () => setState(() => currentFilter = index);
+  }
+
+  Widget _buildTopicButton(String text, int index) {
+    return Container(
+      height: 35,
+      margin: const EdgeInsets.only(right: 10),
+      child: TextButton(
+          style: ButtonStyle(
+            backgroundColor: MaterialStateProperty.all(
+                currentFilter == index ? ColorsInfo.newara : Colors.white),
+            overlayColor:
+                MaterialStateProperty.all(Colors.transparent), // no splash
+            shape: MaterialStateProperty.all(
+              RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(30),
+                side: BorderSide(
+                    color: currentFilter == index
+                        ? ColorsInfo.newara
+                        : const Color(0xFFBBBBBB),
+                    width: 1),
+              ),
+            ),
+          ),
+          onPressed: setCurrentFilterIndex(index),
+          child: Text(
+            text,
+            style: TextStyle(
+              fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
+              color: currentFilter == index
+                  ? Colors.white
+                  : const Color.fromARGB(255, 101, 100, 100),
+            ),
+          )),
+    );
+  }
+
   List<Widget> _buildTopicBoxes(
       BuildContext context, BoardDetailActionModel model) {
     late List<Widget> ret;
     if (model.slug != 'with-school') {
       ret = List<Widget>.generate(model.topics.length, (index) {
-        return Container(
-          height: 35,
-          margin: const EdgeInsets.only(right: 15),
-          child: TextButton(
-              style: ButtonStyle(
-                overlayColor: MaterialStateProperty.all(Colors.transparent),
-                shape: MaterialStateProperty.all(
-                  RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
-                    side: const BorderSide(color: Color(0xFFBBBBBB), width: 1),
-                  ),
-                ),
-              ),
-              onPressed: () {},
-              child: Text(
-                context.locale == const Locale('ko')
-                    ? model.topics[index].ko_name
-                    : model.topics[index].en_name,
-                style: const TextStyle(
-                  fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
-                  color: Color.fromARGB(255, 101, 100, 100),
-                ),
-              )),
-        );
+        return _buildTopicButton(
+            context.locale == const Locale('ko')
+                ? model.topics[index].ko_name
+                : model.topics[index].en_name,
+            index + 1); // total이 첫번째이므로 + 1 씩 크게
       });
     } else {
       ret = [
-        Container(
-          height: 35,
-          margin: const EdgeInsets.only(right: 15),
-          child: TextButton(
-              style: ButtonStyle(
-                overlayColor: MaterialStateProperty.all(Colors.transparent),
-                shape: MaterialStateProperty.all(
-                  RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
-                    side: const BorderSide(color: Color(0xFFBBBBBB), width: 1),
-                  ),
-                ),
-              ),
-              onPressed: () {},
-              child: Text(
-                context.locale == const Locale('ko') ? "달성 전" : "Preparing",
-                style: const TextStyle(
-                  fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
-                  color: Color.fromARGB(255, 101, 100, 100),
-                ),
-              )),
-        ),
-        Container(
-          height: 35,
-          margin: const EdgeInsets.only(right: 15),
-          child: TextButton(
-              style: ButtonStyle(
-                overlayColor: MaterialStateProperty.all(Colors.transparent),
-                shape: MaterialStateProperty.all(
-                  RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
-                    side: const BorderSide(color: Color(0xFFBBBBBB), width: 1),
-                  ),
-                ),
-              ),
-              onPressed: () {},
-              child: Text(
-                context.locale == const Locale('ko') ? "답변 완료" : "Completed",
-                style: const TextStyle(
-                  fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
-                  color: Color.fromARGB(255, 101, 100, 100),
-                ),
-              )),
-        )
+        _buildTopicButton(
+            context.locale == const Locale('ko') ? "달성 전" : "Polling", 1),
+        _buildTopicButton(
+            context.locale == const Locale('ko') ? "답변 준비중" : "Preparing", 2),
+        _buildTopicButton(
+            context.locale == const Locale('ko') ? "답변 완료" : "Answered", 3),
       ];
     }
     return <Widget>[
-          Container(
-            height: 35,
-            margin: const EdgeInsets.only(right: 15),
-            child: TextButton(
-                style: ButtonStyle(
-                  overlayColor: MaterialStateProperty.all(Colors.transparent),
-                  shape: MaterialStateProperty.all(
-                    RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(30),
-                      side:
-                          const BorderSide(color: Color(0xFFBBBBBB), width: 1),
-                    ),
-                  ),
-                ),
-                onPressed: () {},
-                child: Text(
-                  context.locale == const Locale('ko') ? "전체" : "Total",
-                  style: const TextStyle(
-                    fontSize: 16, // PostPreview의 제목과 동일한 폰트 크기
-                    color: Color.fromARGB(255, 101, 100, 100),
-                  ),
-                )),
-          )
+          _buildTopicButton(
+              context.locale == const Locale('ko') ? "전체" : "Total", 0)
         ] +
         ret;
   }
@@ -454,7 +419,7 @@ class _PostListShowPageState extends State<PostListShowPage>
                       if (isTopicsFilterRequired)
                         SizedBox(
                           width: MediaQuery.of(context).size.width - 18,
-                          height: 35,
+                          height: 40,
                           child: SingleChildScrollView(
                             scrollDirection: Axis.horizontal,
                             child: Row(
@@ -467,7 +432,7 @@ class _PostListShowPageState extends State<PostListShowPage>
                         ),
                       if (isTopicsFilterRequired)
                         Container(
-                          margin: EdgeInsets.only(top: 5),
+                          margin: const EdgeInsets.only(top: 5),
                           height: 1,
                           color: const Color(0xFFF0F0F0),
                         ),
@@ -507,27 +472,66 @@ class _PostListShowPageState extends State<PostListShowPage>
                                   ),
                                 );
                               } else {
-                                return InkWell(
-                                  onTap: () async {
-                                    await Navigator.of(context).push(slideRoute(
-                                        PostViewPage(
-                                            id: postPreviewList[index].id)));
-                                    updateAllBulletinList();
-                                  },
-                                  child: Column(
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.all(11.0),
-                                        child: PostPreview(
-                                            model: postPreviewList[index]),
-                                      ),
-                                    ],
-                                  ),
-                                );
+                                // 말머리 필터가 '전체'가 아닌 경우 (학교에게 전합니다 게시판은 아래에서 처리)
+                                if (widget.boardInfo?.slug != 'with-school' &&
+                                    currentFilter != 0) {
+                                  if (postPreviewList[index]
+                                          .parent_topic
+                                          ?.slug !=
+                                      widget.boardInfo
+                                          ?.topics[currentFilter - 1].slug) {
+                                    return Container();
+                                  }
+                                }
+
+                                return (widget.boardInfo?.slug != 'with-school' || widget.boardInfo?.slug ==
+                                            'with-school' &&
+                                        (currentFilter == 0 ||
+                                            postPreviewList[index]
+                                                    .communication_article_status ==
+                                                WithSchoolStatus
+                                                    .values[currentFilter - 1]
+                                                    .index))
+                                    ? InkWell(
+                                        onTap: () async {
+                                          await Navigator.of(context).push(
+                                              slideRoute(PostViewPage(
+                                                  id: postPreviewList[index]
+                                                      .id)));
+                                          updateAllBulletinList();
+                                        },
+                                        child: Column(
+                                          children: [
+                                            Padding(
+                                              padding:
+                                                  const EdgeInsets.all(11.0),
+                                              child: PostPreview(
+                                                  model:
+                                                      postPreviewList[index]),
+                                            ),
+                                          ],
+                                        ),
+                                      )
+                                    : Container();
                               }
                             },
                             separatorBuilder:
                                 (BuildContext context, int index) {
+                              if (widget.boardInfo?.slug != 'with-school' &&
+                                  currentFilter != 0) {
+                                if (postPreviewList[index].parent_topic?.slug !=
+                                    widget.boardInfo?.topics[currentFilter - 1]
+                                        .slug) {
+                                  return Container();
+                                }
+                              }
+                              if (!(widget.boardInfo?.slug != 'with-school' || (widget.boardInfo?.slug == 'with-school' &&
+                                  (currentFilter == 0 ||
+                                      postPreviewList[index]
+                                              .communication_article_status ==
+                                          WithSchoolStatus
+                                              .values[currentFilter - 1]
+                                              .index)))) return Container();
                               return Container(
                                 height: 1,
                                 color: const Color(0xFFF0F0F0),

--- a/lib/utils/with_school.dart
+++ b/lib/utils/with_school.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:new_ara_app/models/board_detail_action_model.dart';
 
 import 'package:new_ara_app/translations/locale_keys.g.dart';
 import 'package:new_ara_app/constants/colors_info.dart';
@@ -28,6 +29,12 @@ String defineCommunicationStatus(int? magicNum) {
   }
 
   return status;
+}
+
+/// 학교에게 전합니다 게시판 인지 여부를 리턴하는 함수
+/// PostListShowPage에서 사용 중.
+bool isWithSchoolBoard(BoardDetailActionModel? model) {
+  return model?.slug == 'with-school';
 }
 
 /// communicationArticleStatus를 전달받고 '달성 전' 상태인지 여부를 리턴


### PR DESCRIPTION
## Overview
기존에 웹에서는 제공되는 기능이었던 게시판별 말머리 필터 기능을 앱에서 제공하기 위한 PR

## Changes
PostListShowPage를 통해 게시판에 접속할 때마다 게시판에 해당하는 말머리가 있는 경우 필터링 버튼이 화면에 표시됨

## Implementaion Method
말머리필터 버튼을 누를 때마다 PostListShowPage의 apiUrl에 적절한 query string parameter를 추가하여 리로드하는 방식으로 구현함

## After Changes
<img width="394" alt="image" src="https://github.com/sparcs-kaist/new-ara-app/assets/48672097/b802e3ea-af08-47a4-aa29-49bed555923b">

## Related Issues
#196 

## Rollback Scenario
post_list_show_page.dart에서 필터링 관련 코드만 지우면 가능

## TODO
디자인 피드백 환영합니다....
