### PR TITLE
PostWritePage에 나가기 확인 dialog 추가

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -139,7 +139,8 @@
         "cancel": "Cancel",
         "confirm": "OK",
         "noBlockedUsers": "There are no blocked users.",
-        "noNickname": "No nickname"
+        "noNickname": "No nickname",
+        "exitConfirm": "Do you really want to go back? Your post will not be saved"
     },
     "popUpMenuButtons": {
         "downloadSucceed": "File downloaded successfully",

--- a/assets/translations/ko.json
+++ b/assets/translations/ko.json
@@ -139,7 +139,8 @@
         "cancel": "취소",
         "confirm": "확인",
         "noBlockedUsers": "차단한 유저가 없습니다.",
-        "noNickname": "닉네임이 없음"
+        "noNickname": "닉네임이 없음",
+        "exitConfirm": "정말로 돌아가시겠습니까? 작성하신 글은 저장되지 않습니다"
     },
     "popUpMenuButtons": {
         "downloadSucceed": "파일 다운로드에 성공했습니다",

--- a/lib/pages/post_write_page.dart
+++ b/lib/pages/post_write_page.dart
@@ -22,6 +22,7 @@ import 'package:new_ara_app/pages/terms_and_conditions_page.dart';
 import 'package:new_ara_app/providers/user_provider.dart';
 import 'package:new_ara_app/utils/cache_function.dart';
 import 'package:new_ara_app/utils/slide_routing.dart';
+import 'package:new_ara_app/widgets/dialogs.dart';
 import 'package:new_ara_app/widgets/loading_indicator.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
@@ -459,6 +460,7 @@ class _PostWritePageState extends State<PostWritePage>
   }
 
   PreferredSizeWidget _buildAppBar(bool canIupload) {
+    UserProvider userProvider = context.read<UserProvider>();
     return AppBar(
       centerTitle: true,
       leading: IconButton(
@@ -469,7 +471,25 @@ class _PostWritePageState extends State<PostWritePage>
             ),
             width: 35,
             height: 35),
-        onPressed: () => Navigator.pop(context),
+        onPressed: () {
+          showDialog(
+              context: context,
+              builder: (context) => ExitConfirmDialog(
+                    userProvider: userProvider,
+                    targetContext: context,
+                    onTap: () {
+                      // 사용자가 미리 뒤로가기 버튼을 누르는 경우 에러 방지를 위해
+                      // try-catch 문을 도입함.
+                      try {
+                        Navigator.of(context)
+                          ..pop() //dialog pop
+                          ..pop(); //PostWritePage pop
+                      } catch (error) {
+                        debugPrint("pop error: $error");
+                      }
+                    },
+                  ));
+        },
       ),
       title: SizedBox(
         child: Text(

--- a/lib/pages/post_write_page.dart
+++ b/lib/pages/post_write_page.dart
@@ -472,23 +472,28 @@ class _PostWritePageState extends State<PostWritePage>
             width: 35,
             height: 35),
         onPressed: () {
-          showDialog(
-              context: context,
-              builder: (context) => ExitConfirmDialog(
-                    userProvider: userProvider,
-                    targetContext: context,
-                    onTap: () {
-                      // 사용자가 미리 뒤로가기 버튼을 누르는 경우 에러 방지를 위해
-                      // try-catch 문을 도입함.
-                      try {
-                        Navigator.of(context)
-                          ..pop() //dialog pop
-                          ..pop(); //PostWritePage pop
-                      } catch (error) {
-                        debugPrint("pop error: $error");
-                      }
-                    },
-                  ));
+          //글이나 제목이 있다면 exitConfirm dialog
+          if (_hasEditorText || _titleController.text != '') {
+            showDialog(
+                context: context,
+                builder: (context) => ExitConfirmDialog(
+                      userProvider: userProvider,
+                      targetContext: context,
+                      onTap: () {
+                        // 사용자가 미리 뒤로가기 버튼을 누르는 경우 에러 방지를 위해
+                        // try-catch 문을 도입함.
+                        try {
+                          Navigator.of(context)
+                            ..pop() //dialog pop
+                            ..pop(); //PostWritePage pop
+                        } catch (error) {
+                          debugPrint("pop error: $error");
+                        }
+                      },
+                    ));
+          } else {
+            Navigator.of(context).pop();
+          }
         },
       ),
       title: SizedBox(

--- a/lib/pages/post_write_page.dart
+++ b/lib/pages/post_write_page.dart
@@ -424,43 +424,62 @@ class _PostWritePageState extends State<PostWritePage>
     //빌드 전 첨부파일의 유효성 확인
     _checkAttachmentsValid();
 
+    UserProvider userProvider = context.read<UserProvider>();
+
     return _isLoading
         ? const LoadingIndicator()
-        : Scaffold(
-            appBar: _buildAppBar(canIupload),
-            body: SafeArea(
-              child: Column(
-                children: [
-                  if (_isKeyboardClosed) _buildMenubar(),
-                  const SizedBox(
-                    height: 15,
-                  ),
-                  _buildTitle(),
-                  const SizedBox(height: 15),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 20),
-                    child: Container(
-                      height: 1,
-                      color: const Color(0xFFF0F0F0),
+        : WillPopScope(
+            onWillPop: () async {
+              if (_hasEditorText || _titleController.text != '') {
+                final shouldPop = await showDialog<bool>(
+                    context: context,
+                    builder: (context) => ExitConfirmDialog(
+                          userProvider: userProvider,
+                          targetContext: context,
+                          onTap: () {
+                            Navigator.pop(context, true); //dialog pop
+                          },
+                        ));
+                return shouldPop ?? false;
+              } else {
+                return true;
+              }
+            },
+            child: Scaffold(
+              appBar: _buildAppBar(canIupload, userProvider),
+              body: SafeArea(
+                child: Column(
+                  children: [
+                    if (_isKeyboardClosed) _buildMenubar(),
+                    const SizedBox(
+                      height: 15,
                     ),
-                  ),
-                  const SizedBox(
-                    height: 15,
-                  ),
-                  _buildToolbar(),
-                  const SizedBox(
-                    height: 10,
-                  ),
-                  Expanded(child: _buildEditor()),
-                  _buildAttachmentShow()
-                ],
+                    _buildTitle(),
+                    const SizedBox(height: 15),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 20),
+                      child: Container(
+                        height: 1,
+                        color: const Color(0xFFF0F0F0),
+                      ),
+                    ),
+                    const SizedBox(
+                      height: 15,
+                    ),
+                    _buildToolbar(),
+                    const SizedBox(
+                      height: 10,
+                    ),
+                    Expanded(child: _buildEditor()),
+                    _buildAttachmentShow()
+                  ],
+                ),
               ),
             ),
           );
   }
 
-  PreferredSizeWidget _buildAppBar(bool canIupload) {
-    UserProvider userProvider = context.read<UserProvider>();
+  PreferredSizeWidget _buildAppBar(bool canIupload, UserProvider userProvider) {
     return AppBar(
       centerTitle: true,
       leading: IconButton(
@@ -471,8 +490,7 @@ class _PostWritePageState extends State<PostWritePage>
             ),
             width: 35,
             height: 35),
-        onPressed: () {
-          //글이나 제목이 있다면 exitConfirm dialog
+        onPressed: () async {
           if (_hasEditorText || _titleController.text != '') {
             showDialog(
                 context: context,
@@ -492,7 +510,7 @@ class _PostWritePageState extends State<PostWritePage>
                       },
                     ));
           } else {
-            Navigator.of(context).pop();
+            Navigator.pop(context);
           }
         },
       ),

--- a/lib/translations/codegen_loader.g.dart
+++ b/lib/translations/codegen_loader.g.dart
@@ -155,7 +155,8 @@ class CodegenLoader extends AssetLoader{
     "cancel": "Cancel",
     "confirm": "OK",
     "noBlockedUsers": "There are no blocked users.",
-    "noNickname": "No nickname"
+    "noNickname": "No nickname",
+    "exitConfirm": "Do you really want to go back? Your post will not be saved"
   },
   "popUpMenuButtons": {
     "downloadSucceed": "File downloaded successfully",
@@ -355,7 +356,8 @@ static const Map<String,dynamic> ko = {
     "cancel": "취소",
     "confirm": "확인",
     "noBlockedUsers": "차단한 유저가 없습니다.",
-    "noNickname": "닉네임이 없음"
+    "noNickname": "닉네임이 없음",
+    "exitConfirm": "정말로 돌아가시겠습니까? 작성하신 글은 저장되지 않습니다"
   },
   "popUpMenuButtons": {
     "downloadSucceed": "파일 다운로드에 성공했습니다",

--- a/lib/translations/locale_keys.g.dart
+++ b/lib/translations/locale_keys.g.dart
@@ -130,6 +130,7 @@ abstract class  LocaleKeys {
   static const dialogs_confirm = 'dialogs.confirm';
   static const dialogs_noBlockedUsers = 'dialogs.noBlockedUsers';
   static const dialogs_noNickname = 'dialogs.noNickname';
+  static const dialogs_exitConfirm = 'dialogs.exitConfirm';
   static const dialogs = 'dialogs';
   static const popUpMenuButtons_downloadSucceed = 'popUpMenuButtons.downloadSucceed';
   static const popUpMenuButtons_downloadFailed = 'popUpMenuButtons.downloadFailed';

--- a/lib/widgets/dialogs.dart
+++ b/lib/widgets/dialogs.dart
@@ -1141,7 +1141,7 @@ class ExitConfirmDialog extends StatelessWidget {
                   onTap: () {
                     // PostWritePage에서 pop해야 하므로
                     // targetContext 사용.
-                    Navigator.pop(targetContext);
+                    Navigator.pop(targetContext, false);
                   },
                   child: Container(
                     decoration: BoxDecoration(

--- a/lib/widgets/dialogs.dart
+++ b/lib/widgets/dialogs.dart
@@ -1081,3 +1081,119 @@ Google Playストアでのアプリのプロダクションレビュー後に遭
     );
   }
 }
+
+/// PostWritePage의 나가기 확인에 사용되는 Dialog
+class ExitConfirmDialog extends StatelessWidget {
+  final UserProvider userProvider;
+
+  /// PostWritePage의 context.
+  final BuildContext targetContext;
+
+  /// '확인' 버튼을 눌렀을 때 적용되는 onTap 메서드
+  final void Function()? onTap;
+
+  const ExitConfirmDialog({
+    super.key,
+    required this.userProvider,
+    required this.targetContext,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: Container(
+        decoration: const BoxDecoration(
+          borderRadius: BorderRadius.all(Radius.circular(15)),
+        ),
+        width: 350,
+        height: 200,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SvgPicture.asset(
+              'assets/icons/warning.svg',
+              width: 55,
+              height: 55,
+              colorFilter: const ColorFilter.mode(
+                ColorsInfo.newara,
+                BlendMode.srcIn,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 25),
+              child: Text(
+                LocaleKeys.dialogs_exitConfirm.tr(),
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.black,
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                InkWell(
+                  onTap: () {
+                    // PostWritePage에서 pop해야 하므로
+                    // targetContext 사용.
+                    Navigator.pop(targetContext);
+                  },
+                  child: Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                        color: Colors.grey,
+                        width: 1,
+                      ),
+                      borderRadius: const BorderRadius.all(Radius.circular(20)),
+                      color: Colors.white,
+                    ),
+                    width: 60,
+                    height: 40,
+                    child: Center(
+                      child: Text(
+                        LocaleKeys.dialogs_cancel.tr(),
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                          color: Colors.black,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                InkWell(
+                  // 인자로 전달받은 onTap 사용.
+                  onTap: onTap,
+                  child: Container(
+                    decoration: const BoxDecoration(
+                      borderRadius: BorderRadius.all(Radius.circular(20)),
+                      color: ColorsInfo.newara,
+                    ),
+                    width: 60,
+                    height: 40,
+                    child: Center(
+                      child: Text(
+                        LocaleKeys.dialogs_confirm.tr(),
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Overview
<!-- 간단하게 이 PR이 무엇인지 설명해주세요. 예: 새로운 로그인 기능 추가 -->
게시글 작성 페이지에서 '나가기 버튼'을 누를 때 2차적으로 확인하도록 함
## Changes
<!-- 이 PR로 인해 변경되는 사항을 나열해주세요. 예:
- 로그인 페이지 UI 업데이트
- 로그인 API 연동
- 로그인 에러 처리 추가
-->
- 나가기 확인 dialog 추가 (글/제목을 적었을 때에만)
- 언어에 맞게 번역
- 고유의 뒤로 돌아가기 (android/ios 모두) 버튼을 누를 때 별도로 처리 (WillPopScope)
## Implementation Method
<!-- 변경사항을 구현한 방법에 대해 특별히 전달해야할 것이 있다면 설명해주세요. 예:
- React Hook을 사용하여 상태 관리
- JWT를 사용한 인증 처리
-->
- dialogs.dart에 ExitConfirmDialog를 추가 (DeleteDialog와 유사)
- post_write_page.dart의 AppBar에 연동
- 이 때, 제목/글이 있는지 확인
- PopScope로 별도 처리 (os 자체의 돌아가기 버튼 / slide 등)
## After Changes
<!-- 변경 사항을 확인 할 수 있는 방법을 알려주세요. 가능하다면, 변화를 보여주는 스크린샷 또는 동영상을 첨부해주세요. 예:
- 로그인 성공 시 홈페이지로 리다이렉트하는 동영상
-->
- 게시물 작성 페이지에서 나갈 시, 확인 dialog 출력
- 
![Uploading Untitled.png…]()

## Related Issues
<!-- 관련 버그 현상이나 관련 이슈 번호가 있다면 링크를 적어주거나 스크린샷을 첨부해주세요. 예: #123 -->
현재 flutter 버전에서 사용되는 WillPopScope가 deprecated됨, 최신 버전에서는 PopScope 사용 권장
## Rollback Scenario
<!-- 해당 PR를 롤백하는 방법과 순서를 알려주세요. 예: 
1. revert commit
2. .env 파일 수정
-->
## TODO
<!-- 앞으로 해야하는 것이나, 논의가 필요한 부분 등을 적어주세요. 예:
- 로그인 관련 테스트 케이스 추가
- 다국어 지원 검토
-->
