### PR TITLE
PostWritePage 내용 임시 저장(tempSave)

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -141,7 +141,8 @@
         "confirm": "OK",
         "noBlockedUsers": "There are no blocked users.",
         "noNickname": "No nickname",
-        "exitConfirm": "Do you really want to go back? Your post will not be saved"
+        "exitConfirm": "Do you really want to go back? Your post will not be saved",
+        "tempSave" : "Save for now"
     },
     "popUpMenuButtons": {
         "downloadSucceed": "File downloaded successfully",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -142,7 +142,7 @@
         "noBlockedUsers": "There are no blocked users.",
         "noNickname": "No nickname",
         "exitConfirm": "Do you really want to go back? Your post will not be saved",
-        "tempSave" : "Save for now"
+        "tempSave" : "Save in drafts"
     },
     "popUpMenuButtons": {
         "downloadSucceed": "File downloaded successfully",

--- a/assets/translations/ko.json
+++ b/assets/translations/ko.json
@@ -142,7 +142,7 @@
         "noBlockedUsers": "차단한 유저가 없습니다.",
         "noNickname": "닉네임이 없음",
         "exitConfirm": "정말로 돌아가시겠습니까? 작성하신 글은 저장되지 않습니다",
-        "tempSave" : "임시 저장"
+        "tempSave" : "임시 저장하기"
     },
     "popUpMenuButtons": {
         "downloadSucceed": "파일 다운로드에 성공했습니다",

--- a/assets/translations/ko.json
+++ b/assets/translations/ko.json
@@ -141,7 +141,8 @@
         "confirm": "확인",
         "noBlockedUsers": "차단한 유저가 없습니다.",
         "noNickname": "닉네임이 없음",
-        "exitConfirm": "정말로 돌아가시겠습니까? 작성하신 글은 저장되지 않습니다"
+        "exitConfirm": "정말로 돌아가시겠습니까? 작성하신 글은 저장되지 않습니다",
+        "tempSave" : "임시 저장"
     },
     "popUpMenuButtons": {
         "downloadSucceed": "파일 다운로드에 성공했습니다",

--- a/lib/pages/post_write_page.dart
+++ b/lib/pages/post_write_page.dart
@@ -436,8 +436,12 @@ class _PostWritePageState extends State<PostWritePage>
                     builder: (context) => ExitConfirmDialog(
                           userProvider: userProvider,
                           targetContext: context,
-                          onTap: () {
+                          onTapConfirm: () {
                             Navigator.pop(context, true); //dialog pop
+                          },
+                          onTapSave: () {
+                            debugPrint("called temporary save");
+                            // TODO: 이하에 caching 구현
                           },
                         ));
                 return shouldPop ?? false;
@@ -497,7 +501,7 @@ class _PostWritePageState extends State<PostWritePage>
                 builder: (context) => ExitConfirmDialog(
                       userProvider: userProvider,
                       targetContext: context,
-                      onTap: () {
+                      onTapConfirm: () {
                         // 사용자가 미리 뒤로가기 버튼을 누르는 경우 에러 방지를 위해
                         // try-catch 문을 도입함.
                         try {
@@ -507,6 +511,10 @@ class _PostWritePageState extends State<PostWritePage>
                         } catch (error) {
                           debugPrint("pop error: $error");
                         }
+                      },
+                      onTapSave: () {
+                        debugPrint("called temporary save");
+                        // TODO: 이하에 caching 구현
                       },
                     ));
           } else {

--- a/lib/translations/codegen_loader.g.dart
+++ b/lib/translations/codegen_loader.g.dart
@@ -157,7 +157,8 @@ class CodegenLoader extends AssetLoader{
     "confirm": "OK",
     "noBlockedUsers": "There are no blocked users.",
     "noNickname": "No nickname",
-    "exitConfirm": "Do you really want to go back? Your post will not be saved"
+    "exitConfirm": "Do you really want to go back? Your post will not be saved",
+    "tempSave": "Save for now"
   },
   "popUpMenuButtons": {
     "downloadSucceed": "File downloaded successfully",
@@ -359,7 +360,8 @@ static const Map<String,dynamic> ko = {
     "confirm": "확인",
     "noBlockedUsers": "차단한 유저가 없습니다.",
     "noNickname": "닉네임이 없음",
-    "exitConfirm": "정말로 돌아가시겠습니까? 작성하신 글은 저장되지 않습니다"
+    "exitConfirm": "정말로 돌아가시겠습니까? 작성하신 글은 저장되지 않습니다",
+    "tempSave": "임시 저장"
   },
   "popUpMenuButtons": {
     "downloadSucceed": "파일 다운로드에 성공했습니다",

--- a/lib/translations/codegen_loader.g.dart
+++ b/lib/translations/codegen_loader.g.dart
@@ -158,7 +158,7 @@ class CodegenLoader extends AssetLoader{
     "noBlockedUsers": "There are no blocked users.",
     "noNickname": "No nickname",
     "exitConfirm": "Do you really want to go back? Your post will not be saved",
-    "tempSave": "Save for now"
+    "tempSave": "Save in drafts"
   },
   "popUpMenuButtons": {
     "downloadSucceed": "File downloaded successfully",
@@ -361,7 +361,7 @@ static const Map<String,dynamic> ko = {
     "noBlockedUsers": "차단한 유저가 없습니다.",
     "noNickname": "닉네임이 없음",
     "exitConfirm": "정말로 돌아가시겠습니까? 작성하신 글은 저장되지 않습니다",
-    "tempSave": "임시 저장"
+    "tempSave": "임시 저장하기"
   },
   "popUpMenuButtons": {
     "downloadSucceed": "파일 다운로드에 성공했습니다",

--- a/lib/translations/locale_keys.g.dart
+++ b/lib/translations/locale_keys.g.dart
@@ -1,34 +1,25 @@
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
-abstract class LocaleKeys {
+abstract class  LocaleKeys {
   static const boardListPage_boards = 'boardListPage.boards';
-  static const boardListPage_searchBoardsPostsComments =
-      'boardListPage.searchBoardsPostsComments';
+  static const boardListPage_searchBoardsPostsComments = 'boardListPage.searchBoardsPostsComments';
   static const boardListPage_viewAll = 'boardListPage.viewAll';
   static const boardListPage_topPosts = 'boardListPage.topPosts';
   static const boardListPage_bookmarks = 'boardListPage.bookmarks';
   static const boardListPage = 'boardListPage';
   static const bulletinSearchPage_searchIn = 'bulletinSearchPage.searchIn';
-  static const bulletinSearchPage_searchInAllPosts =
-      'bulletinSearchPage.searchInAllPosts';
-  static const bulletinSearchPage_searchInHistory =
-      'bulletinSearchPage.searchInHistory';
-  static const bulletinSearchPage_searchInTopPosts =
-      'bulletinSearchPage.searchInTopPosts';
-  static const bulletinSearchPage_searchInBookmarks =
-      'bulletinSearchPage.searchInBookmarks';
+  static const bulletinSearchPage_searchInAllPosts = 'bulletinSearchPage.searchInAllPosts';
+  static const bulletinSearchPage_searchInHistory = 'bulletinSearchPage.searchInHistory';
+  static const bulletinSearchPage_searchInTopPosts = 'bulletinSearchPage.searchInTopPosts';
+  static const bulletinSearchPage_searchInBookmarks = 'bulletinSearchPage.searchInBookmarks';
   static const bulletinSearchPage_search = 'bulletinSearchPage.search';
-  static const bulletinSearchPage_pleaseEnter =
-      'bulletinSearchPage.pleaseEnter';
+  static const bulletinSearchPage_pleaseEnter = 'bulletinSearchPage.pleaseEnter';
   static const bulletinSearchPage_noResults = 'bulletinSearchPage.noResults';
   static const bulletinSearchPage = 'bulletinSearchPage';
   static const inquiryPage_title = 'inquiryPage.title';
-  static const inquiryPage_reLoginErrorWithWithdrawalGuide =
-      'inquiryPage.reLoginErrorWithWithdrawalGuide';
-  static const inquiryPage_reLoginErrorWithWithdrawalEmailTitle =
-      'inquiryPage.reLoginErrorWithWithdrawalEmailTitle';
-  static const inquiryPage_reLoginErrorWithWithdrawalEmailContents =
-      'inquiryPage.reLoginErrorWithWithdrawalEmailContents';
+  static const inquiryPage_reLoginErrorWithWithdrawalGuide = 'inquiryPage.reLoginErrorWithWithdrawalGuide';
+  static const inquiryPage_reLoginErrorWithWithdrawalEmailTitle = 'inquiryPage.reLoginErrorWithWithdrawalEmailTitle';
+  static const inquiryPage_reLoginErrorWithWithdrawalEmailContents = 'inquiryPage.reLoginErrorWithWithdrawalEmailContents';
   static const inquiryPage = 'inquiryPage';
   static const loginPage_login = 'loginPage.login';
   static const loginPage = 'loginPage';
@@ -41,22 +32,18 @@ abstract class LocaleKeys {
   static const mainPage_realEstate = 'mainPage.realEstate';
   static const mainPage_market = 'mainPage.market';
   static const mainPage_jobsWanted = 'mainPage.jobsWanted';
-  static const mainPage_organizationsAndClubs =
-      'mainPage.organizationsAndClubs';
+  static const mainPage_organizationsAndClubs = 'mainPage.organizationsAndClubs';
   static const mainPage_gradAssoc = 'mainPage.gradAssoc';
   static const mainPage_undergradAssoc = 'mainPage.undergradAssoc';
   static const mainPage_freshmanCouncil = 'mainPage.freshmanCouncil';
   static const mainPage_talk = 'mainPage.talk';
   static const mainPage = 'mainPage';
-  static const notificationPage_notifications =
-      'notificationPage.notifications';
-  static const notificationPage_noNotifications =
-      'notificationPage.noNotifications';
+  static const notificationPage_notifications = 'notificationPage.notifications';
+  static const notificationPage_noNotifications = 'notificationPage.noNotifications';
   static const notificationPage_today = 'notificationPage.today';
   static const notificationPage_post = 'notificationPage.post';
   static const notificationPage_newComment = 'notificationPage.newComment';
-  static const notificationPage_allNotificationsChecked =
-      'notificationPage.allNotificationsChecked';
+  static const notificationPage_allNotificationsChecked = 'notificationPage.allNotificationsChecked';
   static const notificationPage = 'notificationPage';
   static const postListShowPage_boards = 'postListShowPage.boards';
   static const postListShowPage_history = 'postListShowPage.history';
@@ -73,16 +60,14 @@ abstract class LocaleKeys {
   static const settingPage_viewBlockedUsers = 'settingPage.viewBlockedUsers';
   static const settingPage_howToBlock = 'settingPage.howToBlock';
   static const settingPage_information = 'settingPage.information';
-  static const settingPage_termsAndConditions =
-      'settingPage.termsAndConditions';
+  static const settingPage_termsAndConditions = 'settingPage.termsAndConditions';
   static const settingPage_contactAdmins = 'settingPage.contactAdmins';
   static const settingPage_signOut = 'settingPage.signOut';
   static const settingPage_withdrawal = 'settingPage.withdrawal';
   static const settingPage_withdrawalGuide = 'settingPage.withdrawalGuide';
   static const settingPage_userBlockingGuide = 'settingPage.userBlockingGuide';
   static const settingPage_settingsSaved = 'settingPage.settingsSaved';
-  static const settingPage_errorSavingSettings =
-      'settingPage.errorSavingSettings';
+  static const settingPage_errorSavingSettings = 'settingPage.errorSavingSettings';
   static const settingPage_myReplies = 'settingPage.myReplies';
   static const settingPage_replies = 'settingPage.replies';
   static const settingPage_hotNotifications = 'settingPage.hotNotifications';
@@ -101,8 +86,7 @@ abstract class LocaleKeys {
   static const postViewPage_scrap = 'postViewPage.scrap';
   static const postViewPage_scrapped = 'postViewPage.scrapped';
   static const postViewPage_share = 'postViewPage.share';
-  static const postViewPage_launchInBrowserNotAvailable =
-      'postViewPage.launchInBrowserNotAvailable';
+  static const postViewPage_launchInBrowserNotAvailable = 'postViewPage.launchInBrowserNotAvailable';
   static const postViewPage_showHiddenPosts = 'postViewPage.showHiddenPosts';
   static const postViewPage_hit = 'postViewPage.hit';
   static const postViewPage_noSelfVotingInfo = 'postViewPage.noSelfVotingInfo';
@@ -114,13 +98,10 @@ abstract class LocaleKeys {
   static const postViewPage_edit = 'postViewPage.edit';
   static const postViewPage_commentHintText = 'postViewPage.commentHintText';
   static const postViewPage_noCommentWarning = 'postViewPage.noCommentWarning';
-  static const postViewPage_displayCommentCount =
-      'postViewPage.displayCommentCount';
-  static const postViewPage_copyLinkToClipBoard =
-      'postViewPage.copyLinkToClipBoard';
+  static const postViewPage_displayCommentCount = 'postViewPage.displayCommentCount';
+  static const postViewPage_copyLinkToClipBoard = 'postViewPage.copyLinkToClipBoard';
   static const postViewPage_blockedUsersPost = 'postViewPage.blockedUsersPost';
-  static const postViewPage_blockedUsersComment =
-      'postViewPage.blockedUsersComment';
+  static const postViewPage_blockedUsersComment = 'postViewPage.blockedUsersComment';
   static const postViewPage_reportedPost = 'postViewPage.reportedPost';
   static const postViewPage_reportedComment = 'postViewPage.reportedComment';
   static const postViewPage_adultPost = 'postViewPage.adultPost';
@@ -129,19 +110,13 @@ abstract class LocaleKeys {
   static const postViewPage_hiddenPost = 'postViewPage.hiddenPost';
   static const postViewPage_deletedComment = 'postViewPage.deletedComment';
   static const postViewPage_hiddenComment = 'postViewPage.hiddenComment';
-  static const postViewPage_blockedUsersContentNotice =
-      'postViewPage.blockedUsersContentNotice';
-  static const postViewPage_adultContentNotice =
-      'postViewPage.adultContentNotice';
-  static const postViewPage_socialContentNotice =
-      'postViewPage.socialContentNotice';
+  static const postViewPage_blockedUsersContentNotice = 'postViewPage.blockedUsersContentNotice';
+  static const postViewPage_adultContentNotice = 'postViewPage.adultContentNotice';
+  static const postViewPage_socialContentNotice = 'postViewPage.socialContentNotice';
   static const postViewPage = 'postViewPage';
-  static const postViewUtils_letUsKnowPostReportReason =
-      'postViewUtils.letUsKnowPostReportReason';
-  static const postViewUtils_letUsKnowCommentReportReason =
-      'postViewUtils.letUsKnowCommentReportReason';
-  static const postViewUtils_reportPostSucceed =
-      'postViewUtils.reportPostSucceed';
+  static const postViewUtils_letUsKnowPostReportReason = 'postViewUtils.letUsKnowPostReportReason';
+  static const postViewUtils_letUsKnowCommentReportReason = 'postViewUtils.letUsKnowCommentReportReason';
+  static const postViewUtils_reportPostSucceed = 'postViewUtils.reportPostSucceed';
   static const postViewUtils_alreadyReported = 'postViewUtils.alreadyReported';
   static const postViewUtils_reportButton = 'postViewUtils.reportButton';
   static const postViewUtils_cancel = 'postViewUtils.cancel';
@@ -157,17 +132,15 @@ abstract class LocaleKeys {
   static const dialogs_noBlockedUsers = 'dialogs.noBlockedUsers';
   static const dialogs_noNickname = 'dialogs.noNickname';
   static const dialogs_exitConfirm = 'dialogs.exitConfirm';
+  static const dialogs_tempSave = 'dialogs.tempSave';
   static const dialogs = 'dialogs';
-  static const popUpMenuButtons_downloadSucceed =
-      'popUpMenuButtons.downloadSucceed';
-  static const popUpMenuButtons_downloadFailed =
-      'popUpMenuButtons.downloadFailed';
+  static const popUpMenuButtons_downloadSucceed = 'popUpMenuButtons.downloadSucceed';
+  static const popUpMenuButtons_downloadFailed = 'popUpMenuButtons.downloadFailed';
   static const popUpMenuButtons_attachments = 'popUpMenuButtons.attachments';
   static const popUpMenuButtons_report = 'popUpMenuButtons.report';
   static const popUpMenuButtons_edit = 'popUpMenuButtons.edit';
   static const popUpMenuButtons_delete = 'popUpMenuButtons.delete';
-  static const popUpMenuButtons_withSchoolInfoText =
-      'popUpMenuButtons.withSchoolInfoText';
+  static const popUpMenuButtons_withSchoolInfoText = 'popUpMenuButtons.withSchoolInfoText';
   static const popUpMenuButtons = 'popUpMenuButtons';
   static const postPreview_blockedUsersPost = 'postPreview.blockedUsersPost';
   static const postPreview_reportedPost = 'postPreview.reportedPost';
@@ -175,24 +148,19 @@ abstract class LocaleKeys {
   static const postPreview_socialPost = 'postPreview.socialPost';
   static const postPreview_accessDeniedPost = 'postPreview.accessDeniedPost';
   static const postPreview_hiddenPost = 'postPreview.hiddenPost';
-  static const postPreview_beforeUpVoteThreshold =
-      'postPreview.beforeUpVoteThreshold';
-  static const postPreview_beforeSchoolConfirm =
-      'postPreview.beforeSchoolConfirm';
+  static const postPreview_beforeUpVoteThreshold = 'postPreview.beforeUpVoteThreshold';
+  static const postPreview_beforeSchoolConfirm = 'postPreview.beforeSchoolConfirm';
   static const postPreview_answerDone = 'postPreview.answerDone';
   static const postPreview = 'postPreview';
-  static const profileEditPage_settingInfoText =
-      'profileEditPage.settingInfoText';
+  static const profileEditPage_settingInfoText = 'profileEditPage.settingInfoText';
   static const profileEditPage_editProfile = 'profileEditPage.editProfile';
   static const profileEditPage_complete = 'profileEditPage.complete';
   static const profileEditPage_nickname = 'profileEditPage.nickname';
   static const profileEditPage_email = 'profileEditPage.email';
   static const profileEditPage_noEmail = 'profileEditPage.noEmail';
   static const profileEditPage_nicknameInfo = 'profileEditPage.nicknameInfo';
-  static const profileEditPage_nicknameHintText =
-      'profileEditPage.nicknameHintText';
-  static const profileEditPage_nicknameEmptyInfo =
-      'profileEditPage.nicknameEmptyInfo';
+  static const profileEditPage_nicknameHintText = 'profileEditPage.nicknameHintText';
+  static const profileEditPage_nicknameEmptyInfo = 'profileEditPage.nicknameEmptyInfo';
   static const profileEditPage = 'profileEditPage';
   static const postWritePage_write = 'postWritePage.write';
   static const postWritePage_submit = 'postWritePage.submit';
@@ -205,18 +173,16 @@ abstract class LocaleKeys {
   static const postWritePage_anonymous = 'postWritePage.anonymous';
   static const postWritePage_adult = 'postWritePage.adult';
   static const postWritePage_politics = 'postWritePage.politics';
-  static const postWritePage_contentPlaceholder =
-      'postWritePage.contentPlaceholder';
-  static const postWritePage_conditionSnackBar =
-      'postWritePage.conditionSnackBar';
+  static const postWritePage_contentPlaceholder = 'postWritePage.contentPlaceholder';
+  static const postWritePage_conditionSnackBar = 'postWritePage.conditionSnackBar';
   static const postWritePage_noCategory = 'postWritePage.noCategory';
   static const postWritePage_selectCategory = 'postWritePage.selectCategory';
   static const postWritePage = 'postWritePage';
-  static const termsAndConditionsPage_termsAndConditions =
-      'termsAndConditionsPage.termsAndConditions';
+  static const termsAndConditionsPage_termsAndConditions = 'termsAndConditionsPage.termsAndConditions';
   static const termsAndConditionsPage_agree = 'termsAndConditionsPage.agree';
   static const termsAndConditionsPage_agreed = 'termsAndConditionsPage.agreed';
   static const termsAndConditionsPage = 'termsAndConditionsPage';
   static const userProvider_internetError = 'userProvider.internetError';
   static const userProvider = 'userProvider';
+
 }

--- a/lib/widgets/dialogs.dart
+++ b/lib/widgets/dialogs.dart
@@ -1150,7 +1150,7 @@ class ExitConfirmDialog extends StatelessWidget {
               children: [
                 InkWell(
                   onTap: () {
-                    // PostWritePage에서 pop해야 하므로
+                    // 이전 페이지(ex:PostWritePage)에서 pop해야 하므로
                     // targetContext 사용.
                     Navigator.pop(targetContext, false);
                   },
@@ -1172,6 +1172,32 @@ class ExitConfirmDialog extends StatelessWidget {
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
                           color: Colors.black,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                InkWell(
+                  onTap: () {
+                    // 글 제목 / 내용 임시 저장하기 구현
+                    debugPrint("called temporary save");
+                    // TODO: 이하에 caching 구현
+                  },
+                  child: Container(
+                    decoration: const BoxDecoration(
+                      borderRadius: BorderRadius.all(Radius.circular(20)),
+                      color: ColorsInfo.newara,
+                    ),
+                    width: 120,
+                    height: 40,
+                    child: Center(
+                      child: Text(
+                        LocaleKeys.dialogs_tempSave.tr(),
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                          color: Colors.white,
                         ),
                       ),
                     ),

--- a/lib/widgets/dialogs.dart
+++ b/lib/widgets/dialogs.dart
@@ -1101,14 +1101,17 @@ class ExitConfirmDialog extends StatelessWidget {
   final BuildContext targetContext;
 
   /// '확인' 버튼을 눌렀을 때 적용되는 onTap 메서드
-  final void Function()? onTap;
+  final void Function()? onTapConfirm;
 
-  const ExitConfirmDialog({
-    super.key,
-    required this.userProvider,
-    required this.targetContext,
-    required this.onTap,
-  });
+  /// '임시 저장' 버튼을 눌렀을 때 적용되는 onTap 메서드
+  final void Function()? onTapSave;
+
+  const ExitConfirmDialog(
+      {super.key,
+      required this.userProvider,
+      required this.targetContext,
+      required this.onTapConfirm,
+      required this.onTapSave});
 
   @override
   Widget build(BuildContext context) {
@@ -1179,16 +1182,13 @@ class ExitConfirmDialog extends StatelessWidget {
                 ),
                 const SizedBox(width: 10),
                 InkWell(
-                  onTap: () {
-                    // 글 제목 / 내용 임시 저장하기 구현
-                    debugPrint("called temporary save");
-                    // TODO: 이하에 caching 구현
-                  },
+                  // 글 제목 / 내용 임시 저장하기 구현
+                  onTap: onTapSave,
                   child: Container(
                     decoration: const BoxDecoration(
-                      borderRadius: BorderRadius.all(Radius.circular(20)),
-                      color: ColorsInfo.newara,
-                    ),
+                        borderRadius: BorderRadius.all(Radius.circular(20)),
+                        color: Colors.grey //ColorsInfo.newaraSoft,
+                        ),
                     width: 120,
                     height: 40,
                     child: Center(
@@ -1205,8 +1205,8 @@ class ExitConfirmDialog extends StatelessWidget {
                 ),
                 const SizedBox(width: 10),
                 InkWell(
-                  // 인자로 전달받은 onTap 사용.
-                  onTap: onTap,
+                  // 나가기(확인) 구현
+                  onTap: onTapConfirm,
                   child: Container(
                     decoration: const BoxDecoration(
                       borderRadius: BorderRadius.all(Radius.circular(20)),

--- a/lib/widgets/dialogs.dart
+++ b/lib/widgets/dialogs.dart
@@ -1183,7 +1183,10 @@ class ExitConfirmDialog extends StatelessWidget {
                 const SizedBox(width: 10),
                 InkWell(
                   // 글 제목 / 내용 임시 저장하기 구현
-                  onTap: onTapSave,
+                  onTap: () {
+                    onTapSave!();
+                    onTapConfirm!();
+                  },
                   child: Container(
                     decoration: const BoxDecoration(
                         borderRadius: BorderRadius.all(Radius.circular(20)),


### PR DESCRIPTION
## Overview
<!-- 간단하게 이 PR이 무엇인지 설명해주세요. 예: 새로운 로그인 기능 추가 -->
postWritePage에 '임시 저장하기' 기능 추가
## Changes
<!-- 이 PR로 인해 변경되는 사항을 나열해주세요. 예:
- 로그인 페이지 UI 업데이트
- 로그인 API 연동
- 로그인 에러 처리 추가
-->
- postWritePage에서 나가기 확인 dialog상 '임시 저장' 버튼 추가
- cache_functions를 활용해 글 제목, 내용, 게시판 등 cache에 저장
- 이후 첫 로딩 시 캐시 여부 확인
## Implementaion Method
<!-- 변경사항을 구현한 방법에 대해 특별히 전달해야할 것이 있다면 설명해주세요. 예:
- React Hook을 사용하여 상태 관리
- JWT를 사용한 인증 처리
-->
- cache_functions를 통해 SharedPreferences에 저장
- dialog에서 '나가기'를 누르면 cache clear
- '임시 저장'을 누를 시 cache에 저장
- 이후 postWritePage 접속 시마다 확인
## After Changes
<!-- 변경 사항을 확인 할 수 있는 방법을 알려주세요. 가능하다면, 변화를 보여주는 스크린샷 또는 동영상을 첨부해주세요. 예:
- 로그인 성공 시 홈페이지로 리다이렉트하는 동영상
-->
- postWritePage에서 나가도 내용을 임시로 저장할 수 있음
## Related Issues
<!-- 관련 버그 현상이나 관련 이슈 번호가 있다면 링크를 적어주거나 스크린샷을 첨부해주세요. 예: #123 -->

## Rollback Scenario
<!-- 해당 PR를 롤백하는 방법과 순서를 알려주세요. 예: 
1. revert commit
2. .env 파일 수정
-->

## TODO
<!-- 앞으로 해야하는 것이나, 논의가 필요한 부분 등을 적어주세요. 예:
- 로그인 관련 테스트 케이스 추가
- 다국어 지원 검토
-->
