### PR TITLE
Caching 속도 최적화 및 임시 저장 수정

### DIFF
--- a/lib/pages/post_write_page.dart
+++ b/lib/pages/post_write_page.dart
@@ -545,11 +545,15 @@ class _PostWritePageState extends State<PostWritePage>
                                 : '/cache/${userID}/';
                             await removeApiData(key);
                             debugPrint('Cache Reset!');
-                            Navigator.pop(context, true);
+                            if (mounted) {
+                              Navigator.pop(context, true);
+                            }
                           },
                           onTapSave: () async {
                             await cacheCurrentData();
-                            Navigator.pop(context, true);
+                            if (mounted) {
+                              Navigator.pop(context, true);
+                            }
                           },
                         ));
                 return shouldPop ?? false;
@@ -623,9 +627,11 @@ class _PostWritePageState extends State<PostWritePage>
                         await removeApiData(key);
                         debugPrint('Cache Reset!');
                         try {
-                          Navigator.of(context)
-                            ..pop() //dialog pop
-                            ..pop(); //PostWritePage pop
+                          if (mounted) {
+                            Navigator.of(context)
+                              ..pop() //dialog pop
+                              ..pop(); //PostWritePage pop
+                          }
                         } catch (error) {
                           debugPrint("pop error: $error");
                         }
@@ -633,9 +639,11 @@ class _PostWritePageState extends State<PostWritePage>
                       onTapSave: () async {
                         await cacheCurrentData();
                         try {
-                          Navigator.of(context)
-                            ..pop() //dialog pop
-                            ..pop(); //PostWritePage pop
+                          if (mounted) {
+                            Navigator.of(context)
+                              ..pop() //dialog pop
+                              ..pop(); //PostWritePage pop
+                          }
                         } catch (error) {
                           debugPrint("pop error: $error");
                         }
@@ -647,7 +655,10 @@ class _PostWritePageState extends State<PostWritePage>
                 : '/cache/${userID}/';
             await removeApiData(key);
             debugPrint('Cache Reset!');
-            Navigator.pop(context);
+
+            if (mounted) {
+              Navigator.pop(context);
+            }
           }
         },
       ),

--- a/lib/pages/post_write_page.dart
+++ b/lib/pages/post_write_page.dart
@@ -266,8 +266,8 @@ class _PostWritePageState extends State<PostWritePage>
   /// 게시판 목록을 가져온다.
   /// 이전 게시물의 데이터를 가져온다.
   Future<void> _initPostWritePost() async {
-    await _getBoardList();
     await _getCachedContents();
+    await _getBoardList();
   }
 
   Future<void> cacheCurrentData() async {
@@ -285,9 +285,11 @@ class _PostWritePageState extends State<PostWritePage>
                   ? 'ANONYMOUS'
                   : 'REGULAR')
           : 'REGULAR',
-      'parent_topic' :  _chosenTopicValue!.id == -1 ? '' : _chosenTopicValue!.slug,
-      'parent_board' : _chosenBoardValue!.id == -1 ? '' : _chosenBoardValue!.slug,
-      'attachments' :  _chosenBoardValue!.id == -1 ? '' : _chosenBoardValue!.slug,
+      'parent_topic':
+          _chosenTopicValue!.id == -1 ? '' : _chosenTopicValue!.slug,
+      'parent_board':
+          _chosenBoardValue!.id == -1 ? '' : _chosenBoardValue!.slug,
+      'attachments': _chosenBoardValue!.id == -1 ? '' : _chosenBoardValue!.slug,
     };
 
     data['attachments'] = _attachmentList;
@@ -298,7 +300,6 @@ class _PostWritePageState extends State<PostWritePage>
 
     await cacheApiData(key, data);
     debugPrint(key);
-    debugPrint(data as String?);
   }
 
   /// 사용자가 선택 가능한 게시판 목록을 가져오는 함수.
@@ -331,34 +332,31 @@ class _PostWritePageState extends State<PostWritePage>
                   return;
                 }
               }
+
+              // 게시판 목록 상태 업데이트.(넘어본 게시판의 정보가 있을 경우 && 게시물을 쓸 수 있는 게시판의 경우)
+              if (widget.previousBoard != null &&
+                  widget.previousBoard!.user_writable) {
+                BoardDetailActionModel boardDetailActionModel =
+                    _findBoardListValue(widget.previousBoard!.slug);
+                _specTopicList = [_defaultTopicModelNone];
+                _specTopicList.addAll(boardDetailActionModel.topics);
+
+                _chosenTopicValue = _specTopicList[0];
+
+                _chosenBoardValue = boardDetailActionModel;
+                _isLoading = false;
+              }
+
+              // 게시판 목록 상태 업데이트(else)
+              else {
+                _specTopicList.add(_defaultTopicModelSelect);
+                _chosenTopicValue = _specTopicList[0];
+                _chosenBoardValue = _boardList[0];
+                _isLoading = false;
+              }
             });
           }
         });
-
-    // 게시판 목록 상태 업데이트.(넘어본 게시판의 정보가 있을 경우 && 게시물을 쓸 수 있는 게시판의 경우)
-    if (widget.previousBoard != null && widget.previousBoard!.user_writable) {
-      setState(() {
-        BoardDetailActionModel boardDetailActionModel =
-            _findBoardListValue(widget.previousBoard!.slug);
-        _specTopicList = [_defaultTopicModelNone];
-        _specTopicList.addAll(boardDetailActionModel.topics);
-
-        _chosenTopicValue = _specTopicList[0];
-
-        _chosenBoardValue = boardDetailActionModel;
-        _isLoading = false;
-      });
-    }
-
-    // 게시판 목록 상태 업데이트(else)
-    else {
-      setState(() {
-        _specTopicList.add(_defaultTopicModelSelect);
-        _chosenTopicValue = _specTopicList[0];
-        _chosenBoardValue = _boardList[0];
-        _isLoading = false;
-      });
-    }
   }
 
   Future<void> _getCachedContents() async {
@@ -406,7 +404,7 @@ class _PostWritePageState extends State<PostWritePage>
       _selectedCheckboxes[0] = cachedData['name_type'] == 2 ? true : false;
       _selectedCheckboxes[1] = cachedData['is_content_sexual'] ?? false;
       _selectedCheckboxes[2] = cachedData['is_content_social'] ?? false;
-      _isLoading = false;
+      //_isLoading = false; (only finish loading AFTER boardlist load)
     });
 
     setState(() {

--- a/lib/utils/cache_function.dart
+++ b/lib/utils/cache_function.dart
@@ -48,13 +48,12 @@ Future<void> updateStateWithCachedOrFetchedApiData({
 
     if (recentJson != null) {
       // 캐시된 데이터가 있으면 콜백 함수를 통해 상태를 업데이트합니다.
-      debugPrint('fetched data: $apiUrl');
       await callback(recentJson);
     }
     // UserProvider를 통해 API로부터 새로운 데이터를 요청합니다.
     Response? response = await userProvider.getApiRes(apiUrl);
 
-    debugPrint('got response: $apiUrl');
+    //debugPrint('got response: $apiUrl');
 
     if (response != null) {
       // 새로운 데이터를 캐시에 저장하고, 콜백 함수를 통해 상태를 업데이트합니다.
@@ -66,4 +65,12 @@ Future<void> updateStateWithCachedOrFetchedApiData({
         "updateStateWithCachedOrFetchedApiData error: $error, apiurl: $apiUrl");
     // 에러 발생 시 적절한 에러 처리 로직을 추가합니다.
   }
+}
+
+/// SharedPreferences에 저장된 값을 리셋(제거)하는 함수입니다.
+///
+/// [key]는 API URL을 의미하며, 해당 값의 데이터는 지워집니다.
+Future<void> removeApiData(String key) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.remove(key);
 }

--- a/lib/utils/cache_function.dart
+++ b/lib/utils/cache_function.dart
@@ -45,12 +45,16 @@ Future<void> updateStateWithCachedOrFetchedApiData({
   try {
     // 캐시에서 최근 JSON 데이터를 시도하여 불러옵니다.
     final dynamic recentJson = await fetchCachedApiData(apiUrl);
+
     if (recentJson != null) {
       // 캐시된 데이터가 있으면 콜백 함수를 통해 상태를 업데이트합니다.
+      debugPrint('fetched data: $apiUrl');
       await callback(recentJson);
     }
     // UserProvider를 통해 API로부터 새로운 데이터를 요청합니다.
     Response? response = await userProvider.getApiRes(apiUrl);
+
+    debugPrint('got response: $apiUrl');
 
     if (response != null) {
       // 새로운 데이터를 캐시에 저장하고, 콜백 함수를 통해 상태를 업데이트합니다.
@@ -58,7 +62,8 @@ Future<void> updateStateWithCachedOrFetchedApiData({
       await callback(response.data);
     }
   } catch (error) {
-    debugPrint("updateStateWithCachedOrFetchedApiData error: $error, apiurl: $apiUrl");
+    debugPrint(
+        "updateStateWithCachedOrFetchedApiData error: $error, apiurl: $apiUrl");
     // 에러 발생 시 적절한 에러 처리 로직을 추가합니다.
   }
 }


### PR DESCRIPTION
## Overview
<!-- 간단하게 이 PR이 무엇인지 설명해주세요. 예: 새로운 로그인 기능 추가 -->
Cache 저장 및 불러오기의 속도를 대폭 증가시킴.
## Changes
<!-- 이 PR로 인해 변경되는 사항을 나열해주세요. 예:
- 로그인 페이지 UI 업데이트
- 로그인 API 연동
- 로그인 에러 처리 추가
-->
- PostWritePage 로딩 속도 대폭 상승

## Implementaion Method
<!-- 변경사항을 구현한 방법에 대해 특별히 전달해야할 것이 있다면 설명해주세요. 예:
- React Hook을 사용하여 상태 관리
- JWT를 사용한 인증 처리
-->
- 기존의 caching 지연 원인 : cache는 SharedPreferences에서 잘 호출되었으나, 업데이트하는 과정에서 _isLoading=false가 늦게 호출 (updateStateWithFetchedOrCachedData 완료 이후)되면서 로딩화면이 계속됨.
- _getBoardList, _getCachedContents,  (임시 저장, 게시판 목록)을 순서대로 불러와 최종적으로 _getBoardList의 업데이트에 따라 setState가 호출되도록 변경
- 또한 _isLoading=false 를 setState() 내부에 통합시킴으로써 바로 화면이 build되도록 변경.
- '임시 저장' 기능의 api 주소를 변경하고 '확인 / OnTapConfirm' 시 리셋하도록 (removeApiCache) 변경.
## After Changes
<!-- 변경 사항을 확인 할 수 있는 방법을 알려주세요. 가능하다면, 변화를 보여주는 스크린샷 또는 동영상을 첨부해주세요. 예:
- 로그인 성공 시 홈페이지로 리다이렉트하는 동영상
-->

## Related Issues
<!-- 관련 버그 현상이나 관련 이슈 번호가 있다면 링크를 적어주거나 스크린샷을 첨부해주세요. 예: #123 -->

## Rollback Scenario
<!-- 해당 PR를 롤백하는 방법과 순서를 알려주세요. 예: 
1. revert commit
2. .env 파일 수정
-->

## TODO
<!-- 앞으로 해야하는 것이나, 논의가 필요한 부분 등을 적어주세요. 예:
- 로그인 관련 테스트 케이스 추가
- 다국어 지원 검토
-->
