### PR TITLE
main으로 push한 수정사항을 dev에도 반영

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,7 +32,11 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    /* compileSdkVersion
+    - 앱을 컴파일할 때 사용하는 SDK의 버전
+    - compileSdkVersion에서 지정한 SDK의 Android API를 사용하게 됨
+    - 구글 정책(2024.08.31 이후로 앱은 API 버전 34를 타겟팅해야함)에 따라 33->34로 상향 */
+    compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -53,9 +57,16 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
 
-       // minSdkVersion 19 // webview_flutter에서 요구하는 최소 버전
-        minSdkVersion 21 // multiDex에서 요구하는 최소 버전
-        targetSdkVersion flutter.targetSdkVersion
+        /* minSdkVersion
+        - 앱이 설치될 수 있는 최소한의 API 버전 (이 버전보다 낮은 것만 지원하는 기기에는 설치 불가)
+        - multiDex에서 요구하는 최소 버전인 21로 설정 */
+        minSdkVersion 21
+
+        /* targetSdkVersion
+        - 앱이 테스트되고 최적화된 Android SDK 버전을 의미
+        - targetSdkVersion에 해당하는 Android SDK 버전을 염두해두고 개발되었다는 의미 
+        - 구글 정책(2024.08.31 이후로 앱은 API 버전 34를 타겟팅해야함)에 따라 33->34로 상향 */
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/lib/pages/post_write_page.dart
+++ b/lib/pages/post_write_page.dart
@@ -1696,7 +1696,7 @@ class _PostWritePageState extends State<PostWritePage>
                   filename: attachFile.path.split('/').last),
             });
             Response? response = await userProvider.postApiRes(
-                "$newAraDefaultUrl/api/attachments/",
+                "attachments/",
                 data: formData);
             if (response != null) {
               final attachmentModel = AttachmentModel.fromJson(response.data);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -137,14 +137,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
-  dbus:
-    dependency: transitive
-    description:
-      name: dbus
-      sha256: "6f07cba3f7b3448d42d015bfd3d53fe12e5b36da2423f23838efc1d5fb31a263"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.8"
   delta_to_html:
     dependency: "direct main"
     description:
@@ -387,30 +379,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
-  flutter_local_notifications:
-    dependency: "direct main"
-    description:
-      name: flutter_local_notifications
-      sha256: "501ed9d54f1c8c0535b7991bade36f9e7e3b45a2346401f03775c1ec7a3c06ae"
-      url: "https://pub.dev"
-    source: hosted
-    version: "15.1.2"
-  flutter_local_notifications_linux:
-    dependency: transitive
-    description:
-      name: flutter_local_notifications_linux
-      sha256: "33f741ef47b5f63cc7f78fe75eeeac7e19f171ff3c3df054d84c1e38bedb6a03"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0+1"
-  flutter_local_notifications_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_local_notifications_platform_interface
-      sha256: "7cf643d6d5022f3baed0be777b0662cce5919c0a7b86e700299f22dc4ae660ef"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.0+1"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -1244,14 +1212,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.3"
-  timezone:
-    dependency: transitive
-    description:
-      name: timezone
-      sha256: "1cfd8ddc2d1cfd836bc93e67b9be88c3adaeca6f40a00ca999104c30693cdca0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.2"
   tuple:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,6 @@ dependencies:
   flutter_keyboard_visibility: "^5.4.1"
   mime: "^1.0.4"
   http_parser: "^4.0.2"
-  flutter_local_notifications: "^15.1.0+1"
   flutter_quill_extensions: "^0.5.0"
   flutter_quill: "^7.4.7"
   delta_to_html: "^0.2.2"


### PR DESCRIPTION
## Overview
1. PostWritePage에서 첨부파일에 대한 request url을 정상적으로 복구함
2. Android Target API 버전을 33에서 34로 상향
3. 사용하지 않는 패키지인 flutter_local_notification을 제거함

## Changes

## Implementaion Method
post_write_page.dart, build.gradle 수정함

## After Changes

## Related Issues

## Rollback Scenario

## TODO
dev로 머지한 후 PostWritePage 관련 다른 기능들에서 발생하던 에러가 여전히 나타나는지 확인해보아야함.
Flutter 버전을 3.22 정도로 상향시키는 작업이 필요할듯(점점 iOS, Android 모두 플러터 3.13이 타겟팅하는 버전대와는 멀어지는 현상)
