### PR TITLE
force HTTPS on iOS app

### DIFF
--- a/lib/pages/sparcs_sso_page.dart
+++ b/lib/pages/sparcs_sso_page.dart
@@ -52,6 +52,13 @@ class _SparcsSSOPageState extends State<SparcsSSOPage> {
       ..setNavigationDelegate(NavigationDelegate(
         onNavigationRequest: (NavigationRequest request) async {
           Uri uri = Uri.parse(request.url);
+          // KAIST SSO의 redirect url이 http를 사용하여 iOS에서 접속이 불가능, https로 강제
+          if (Platform.isIOS && uri.scheme == 'http' && uri.authority == 'sso.kaist.ac.kr') {
+            final httpsUri = uri.replace(scheme: 'https');
+            debugPrint('http 요청을 https로 변경: $uri -> $httpsUri');
+            await _controller.loadRequest(httpsUri);
+            return NavigationDecision.navigate;
+          }
           // SPARCS SSO 페이지에서 개발팀, 관리자에게 연락하기 기능이
           // mailto scheme을 사용하는데 웹뷰에서 잘 처리가 되지 않아 비활성화시켜둠.
           if (uri.scheme == 'mailto') {


### PR DESCRIPTION
## Overview
iOS의 WebView는 기본 정책상 HTTP를 사용할 수 없습니다.  [NSAppTransportSecurity](https://developer.apple.com/documentation/bundleresources/information-property-list/nsapptransportsecurity)
따라서 로그인 시 KAIST SSO의 리디렉션 URL을 HTTPS로 강제 변경합니다. 

## Changes
- 로그인 시 `sso.kaist.ac.kr` 도메인의 모든 HTTP 요청을 HTTPS로 강제 변경

## Implementaion Method
- `sparcs_sso_page.dart`의 `NavigationDelegate`에서 `Platform.isIOS`가 `true`인 경우 위 변경사항 적용

## After Changes
- iOS에서 로그인 시 KAIST IAM 사용 가능

## Related Issues
- iOS에서 KAIST IAM으로 로그인 할 수 없는 issue

## Rollback Scenario
1. Revert commit

## TODO
- SPARCS SSO -> KAIST IAM 로그인 flow에서 http 연결이 사용되지 않도록 수정 필요
