### PR TITLE
Add WebView bridge stack for v2 migration

### DIFF
--- a/lib/bridge/bridge_controller.dart
+++ b/lib/bridge/bridge_controller.dart
@@ -1,0 +1,332 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show Platform;
+import 'dart:ui' show PlatformDispatcher;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'bridge_protocol.dart';
+
+/// Owns the WebView ↔ native message channel.
+///
+/// Each `InAppWebView` registers `FlutterChannel` and forwards `postMessage`
+/// payloads here via [handleMessage]. We dispatch to the right handler and
+/// (if the message had an `id`) post a `:result` / `:error` envelope back
+/// using `evaluateJavascript`.
+class BridgeController with WidgetsBindingObserver {
+  BridgeController({required this.getWebView, this.getPullToRefresh});
+
+  /// Lazily resolves the current InAppWebViewController. We don't hold a
+  /// strong ref because the controller can change across hot reloads.
+  final InAppWebViewController? Function() getWebView;
+
+  /// Lazily resolves the current PullToRefreshController, if the shell
+  /// installed one. Used so the `refreshDone` command from web can call
+  /// `endRefreshing()` and dismiss the native spinner.
+  final PullToRefreshController? Function()? getPullToRefresh;
+
+  bool _started = false;
+
+  void start() {
+    if (_started) return;
+    _started = true;
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Web → Native
+  // ---------------------------------------------------------------------------
+
+  /// Called from the InAppWebView JS handler.
+  Future<void> handleMessage(List<dynamic> args) async {
+    if (args.isEmpty) return;
+    final raw = args.first;
+    if (raw is! String) {
+      _logWarn('FlutterChannel: non-string payload ignored: $raw');
+      return;
+    }
+
+    // Legacy strings: 'PostWritePageExit', 'meal_page_exit', a height string, etc.
+    Map<String, dynamic> env;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        _logInfo('FlutterChannel(legacy): $raw');
+        _handleLegacy(raw);
+        return;
+      }
+      env = decoded;
+    } catch (_) {
+      _logInfo('FlutterChannel(legacy): $raw');
+      _handleLegacy(raw);
+      return;
+    }
+
+    if (env['v'] != kProtocolVersion) {
+      _logWarn('Unsupported protocol version: ${env['v']}');
+      return;
+    }
+
+    final id = env['id'] as String?;
+    final type = env['type'] as String?;
+    final payload = env['payload'];
+    if (type == null) return;
+
+    try {
+      final result = await _dispatch(type, payload);
+      if (id != null) {
+        await _postBack(<String, dynamic>{
+          'v': kProtocolVersion,
+          'id': id,
+          'type': '$type:result',
+          if (result != null) 'payload': result,
+        });
+      }
+    } on BridgeException catch (e) {
+      if (id != null) {
+        await _postBack(<String, dynamic>{
+          'v': kProtocolVersion,
+          'id': id,
+          'type': '$type:error',
+          'error': {'code': e.code, 'message': e.message},
+        });
+      }
+    } catch (e, st) {
+      _logWarn('bridge.$type threw: $e\n$st');
+      if (id != null) {
+        await _postBack(<String, dynamic>{
+          'v': kProtocolVersion,
+          'id': id,
+          'type': '$type:error',
+          'error': {
+            'code': BridgeErrorCode.internal,
+            'message': e.toString(),
+          },
+        });
+      }
+    }
+  }
+
+  void _handleLegacy(String raw) {
+    // Best-effort routing for the existing string-only messages.
+    if (raw == 'PostWritePageExit' || raw == 'meal_page_exit') {
+      // In the new single-shell world there is no native page to pop; the web
+      // owns navigation. We only emit a hint.
+      _logInfo('legacy exit message: $raw');
+      return;
+    }
+    final n = num.tryParse(raw);
+    if (n != null) {
+      // Treat as legacy HeightChannel report. No-op for now.
+      return;
+    }
+  }
+
+  Future<dynamic> _dispatch(String type, dynamic payload) async {
+    switch (type) {
+      case BridgeCommand.ready:
+        await _emitReady(route: (payload as Map?)?['route'] as String?);
+        return null;
+      case BridgeCommand.log:
+        final p = (payload as Map?) ?? const {};
+        debugPrint('[web] ${p['level']}: ${p['message']}');
+        return null;
+      case BridgeCommand.goBack:
+      case BridgeCommand.exit:
+        // The shell owns the back stack; we let the web drive history.
+        await _maybePopOrExit();
+        return null;
+      case BridgeCommand.openExternal:
+        final url = (payload as Map?)?['url'] as String?;
+        if (url == null) {
+          throw BridgeException(BridgeErrorCode.invalidPayload, 'url required');
+        }
+        final ok = await launchUrl(
+          Uri.parse(url),
+          mode: LaunchMode.externalApplication,
+        );
+        if (!ok) {
+          throw BridgeException(BridgeErrorCode.unavailable, 'cannot open url');
+        }
+        return null;
+      case BridgeCommand.haptic:
+        final kind = (payload as Map?)?['kind'] as String?;
+        switch (kind) {
+          case 'light':
+            await HapticFeedback.lightImpact();
+            break;
+          case 'medium':
+            await HapticFeedback.mediumImpact();
+            break;
+          case 'heavy':
+            await HapticFeedback.heavyImpact();
+            break;
+          case 'selection':
+          default:
+            await HapticFeedback.selectionClick();
+        }
+        return null;
+      case BridgeCommand.clipboardWrite:
+        final text = (payload as Map?)?['text'] as String?;
+        if (text == null) {
+          throw BridgeException(BridgeErrorCode.invalidPayload, 'text required');
+        }
+        await Clipboard.setData(ClipboardData(text: text));
+        return null;
+      case BridgeCommand.clipboardRead:
+        final data = await Clipboard.getData(Clipboard.kTextPlain);
+        return {'text': data?.text ?? ''};
+      case BridgeCommand.share:
+        // OS share is wired up later via share_plus; surface as unsupported for now.
+        throw BridgeException(BridgeErrorCode.unsupported, 'share not yet wired');
+      case BridgeCommand.pickImage:
+      case BridgeCommand.pickFile:
+        // The web's <input type=file> picker is good enough for v1; native
+        // picker delegation can be added later without changing the protocol.
+        throw BridgeException(BridgeErrorCode.unsupported, 'use HTML <input type="file">');
+      case BridgeCommand.requestPermission:
+        // Camera / photos prompts are triggered by the OS when the WebView
+        // file picker is invoked. Notifications permission requires the
+        // push integration to be active; respond as denied/unsupported.
+        return {
+          'granted': false,
+          'status': 'denied',
+        };
+      case BridgeCommand.getPushToken:
+        // Stubbed until firebase_messaging is set up. Web should treat a null
+        // token as "push not available yet".
+        return {'token': null, 'platform': Platform.isIOS ? 'apns' : 'fcm'};
+      case BridgeCommand.subscribeTopic:
+      case BridgeCommand.unsubscribeTopic:
+      case BridgeCommand.setBadgeCount:
+        return null;
+      case BridgeCommand.setSession:
+      case BridgeCommand.clearSession:
+        // Cookies live in the WebView cookie jar; we don't mirror them yet.
+        return null;
+      case BridgeCommand.setStatusBar:
+      case BridgeCommand.setSafeArea:
+      case BridgeCommand.reportHeight:
+        return null;
+      case BridgeCommand.refreshDone:
+        getPullToRefresh?.call()?.endRefreshing();
+        return null;
+      default:
+        throw BridgeException(BridgeErrorCode.unsupported, 'unknown command: $type');
+    }
+  }
+
+  Future<void> _maybePopOrExit() async {
+    final wv = getWebView();
+    if (wv == null) return;
+    if (await wv.canGoBack()) {
+      await wv.goBack();
+    } else {
+      await SystemNavigator.pop();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Native → Web
+  // ---------------------------------------------------------------------------
+
+  Future<void> emit(String type, [Map<String, dynamic>? payload]) async {
+    await _postBack(<String, dynamic>{
+      'v': kProtocolVersion,
+      'type': type,
+      if (payload != null) 'payload': payload,
+    });
+  }
+
+  Future<void> _postBack(Map<String, dynamic> envelope) async {
+    final wv = getWebView();
+    if (wv == null) return;
+    final json = jsonEncode(envelope);
+    // The CustomEvent constructor signature differs between platforms; this
+    // form is the safest cross-browser shape and works in WKWebView and
+    // modern Android WebView.
+    final js = '''
+      (function(d){
+        try {
+          var detail = d;
+          window.dispatchEvent(new CustomEvent('$kJsEventName', { detail: detail }));
+        } catch (e) { console.warn('[bridge] dispatch failed', e); }
+      })($json);
+    ''';
+    try {
+      await wv.evaluateJavascript(source: js);
+    } catch (e) {
+      _logWarn('evaluateJavascript failed: $e');
+    }
+  }
+
+  Future<void> _emitReady({String? route}) async {
+    String appVersion = '0.0.0';
+    try {
+      final info = await PackageInfo.fromPlatform();
+      appVersion = '${info.version}+${info.buildNumber}';
+    } catch (_) {}
+
+    final view = WidgetsBinding.instance.platformDispatcher.views.firstOrNull;
+    final padding = view?.padding;
+    final dpr = view?.devicePixelRatio ?? 1.0;
+    EdgeInsets safe = EdgeInsets.zero;
+    if (padding != null) {
+      safe = EdgeInsets.fromLTRB(
+        padding.left / dpr,
+        padding.top / dpr,
+        padding.right / dpr,
+        padding.bottom / dpr,
+      );
+    }
+
+    final locale = PlatformDispatcher.instance.locale;
+
+    await emit(BridgeEvent.ready, {
+      'platform': Platform.isIOS ? 'ios' : 'android',
+      'osVersion': Platform.operatingSystemVersion,
+      'appVersion': appVersion,
+      'locale': locale.toLanguageTag(),
+      'safeArea': {
+        'top': safe.top,
+        'bottom': safe.bottom,
+        'left': safe.left,
+        'right': safe.right,
+      },
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    final mapped = switch (state) {
+      AppLifecycleState.resumed => 'foreground',
+      AppLifecycleState.paused || AppLifecycleState.hidden => 'background',
+      AppLifecycleState.inactive || AppLifecycleState.detached => 'inactive',
+    };
+    emit(BridgeEvent.appStateChanged, {'state': mapped});
+  }
+
+  // ---------------------------------------------------------------------------
+  // Logging
+  // ---------------------------------------------------------------------------
+
+  void _logInfo(Object o) => debugPrint('[bridge] $o');
+  void _logWarn(Object o) => debugPrint('[bridge][WARN] $o');
+}
+
+extension _FirstOrNull<E> on Iterable<E> {
+  E? get firstOrNull => isEmpty ? null : first;
+}

--- a/lib/bridge/bridge_protocol.dart
+++ b/lib/bridge/bridge_protocol.dart
@@ -1,0 +1,79 @@
+/// Bridge protocol constants — keep in sync with
+/// `new-ara-web-v2/src/app/web_view/_bridge/types.ts`.
+///
+/// Wire format (web → native): JSON string posted via the `FlutterChannel`
+/// JS handler:
+///   { v: 1, id?: string, type: string, payload?: any }
+///
+/// Wire format (native → web): a CustomEvent dispatched on `window`:
+///   window.dispatchEvent(new CustomEvent('flutter:message', { detail: <envelope> }))
+library;
+
+const int kProtocolVersion = 1;
+
+/// JS handler name registered on the InAppWebView. The web side calls
+/// `window.FlutterChannel.postMessage(stringifiedEnvelope)`.
+const String kJsHandlerName = 'FlutterChannel';
+
+/// Name of the CustomEvent dispatched in the page when native sends a message.
+const String kJsEventName = 'flutter:message';
+
+/// Web → Native command types.
+class BridgeCommand {
+  static const ready = 'ready';
+  static const log = 'log';
+  static const goBack = 'goBack';
+  static const exit = 'exit';
+  static const setStatusBar = 'setStatusBar';
+  static const setSafeArea = 'setSafeArea';
+  static const openExternal = 'openExternal';
+  static const share = 'share';
+  static const pickImage = 'pickImage';
+  static const pickFile = 'pickFile';
+  static const requestPermission = 'requestPermission';
+  static const getPushToken = 'getPushToken';
+  static const subscribeTopic = 'subscribeTopic';
+  static const unsubscribeTopic = 'unsubscribeTopic';
+  static const setBadgeCount = 'setBadgeCount';
+  static const haptic = 'haptic';
+  static const clipboardWrite = 'clipboardWrite';
+  static const clipboardRead = 'clipboardRead';
+  static const setSession = 'setSession';
+  static const clearSession = 'clearSession';
+  static const reportHeight = 'reportHeight';
+  /// Web tells the native shell that the pull-to-refresh refetch is finished.
+  static const refreshDone = 'refreshDone';
+}
+
+/// Native → Web event types.
+class BridgeEvent {
+  static const ready = 'bridge:ready';
+  static const backPressed = 'back:pressed';
+  static const appStateChanged = 'appstate:changed';
+  static const networkChanged = 'network:changed';
+  static const keyboardChanged = 'keyboard:changed';
+  static const pushReceived = 'push:received';
+  static const pushOpened = 'push:opened';
+  static const deeplinkReceived = 'deeplink:received';
+  static const authExpired = 'auth:expired';
+  /// User pulled the WebView down past the threshold; web should refetch.
+  static const refreshRequested = 'refresh:requested';
+}
+
+/// Error codes used in `:error` envelopes.
+class BridgeErrorCode {
+  static const unsupported = 'unsupported';
+  static const denied = 'denied';
+  static const cancelled = 'cancelled';
+  static const invalidPayload = 'invalid_payload';
+  static const unavailable = 'unavailable';
+  static const internal = 'internal';
+}
+
+class BridgeException implements Exception {
+  final String code;
+  final String message;
+  BridgeException(this.code, this.message);
+  @override
+  String toString() => 'BridgeException($code): $message';
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,193 +1,230 @@
+import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
-import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:new_ara_app/constants/theme_info.dart';
-import 'package:new_ara_app/constants/url_info.dart';
-import 'package:new_ara_app/providers/theme_provider.dart';
-import 'package:new_ara_app/providers/connectivity_provider.dart';
-import 'package:new_ara_app/translations/codegen_loader.g.dart';
-import 'package:new_ara_app/utils/cache_function.dart';
-import 'package:new_ara_app/utils/global_key.dart';
-import 'package:new_ara_app/widgets/loading_indicator.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
-import 'package:new_ara_app/pages/main_navigation_tab_page.dart';
-import 'package:new_ara_app/pages/login_page.dart';
-import 'package:new_ara_app/providers/user_provider.dart';
-import 'package:new_ara_app/providers/notification_provider.dart';
-import 'package:new_ara_app/providers/blocked_provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
-/// 앱에서 지원하는 언어 설정
-final supportedLocales = [
-  const Locale('en'),
-  const Locale('ko'),
-];
+import 'package:new_ara_app/bridge/bridge_controller.dart';
+import 'package:new_ara_app/bridge/bridge_protocol.dart';
+import 'package:new_ara_app/constants/url_info.dart';
 
+/// Entry point for the WebView-shell build of Ara.
+///
+/// The native side is intentionally tiny: load a single InAppWebView pointing
+/// at `$newAraDefaultUrl/web_view/Main`, register the `FlutterChannel`
+/// handler, and forward lifecycle/back events through the bridge. Everything
+/// else lives in the Next.js app.
 void main() async {
-  WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+  final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
-  await EasyLocalization.ensureInitialized();
 
-  // .env.delevopment 또는 .env.production 파일을 읽어서 환경변수 설정
-  // ex) flutter run --dart-define=ENV=development
-  // ex) flutter run --dart-define=ENV=production
   const String environment =
-  String.fromEnvironment('ENV', defaultValue: 'development');
-  await dotenv.load(fileName: ".env.$environment");
+      String.fromEnvironment('ENV', defaultValue: 'development');
+  await dotenv.load(fileName: '.env.$environment');
 
   newAraDefaultUrl = dotenv.env['NEW_ARA_DEFAULT_URL']!;
   newAraAuthority = dotenv.env['NEW_ARA_AUTHORITY']!;
   sparcsSSODefaultUrl = dotenv.env['SPARCS_SSO_DEFAULT_URL']!;
 
-  final isDarkMode = await fetchCachedApiData('cache/dark_mode_setting') ??
-      SchedulerBinding.instance.platformDispatcher.platformBrightness == Brightness.dark;
-  print(isDarkMode);
-
-  // 앱 시작점. 다국어 지원 및 여러 데이터 제공자를 포함한 구조로 설정
-  runApp(
-    EasyLocalization(
-      supportedLocales: supportedLocales,
-      path: 'assets/translations',
-      fallbackLocale: const Locale('en'),
-      startLocale: const Locale('ko'),
-      assetLoader: const CodegenLoader(),
-      child: MultiProvider(
-        providers: [
-          ChangeNotifierProvider(create: (_) => UserProvider()),
-          ChangeNotifierProxyProvider<UserProvider, NotificationProvider>(
-              create: (_) => NotificationProvider(),
-              // 사용자 정보가 업데이트될 때마다 알림 제공자를 업데이트
-              update: (_, userProvider, notificationProvider) {
-                return notificationProvider!
-                  ..updateCookie(userProvider.getCookiesToString());
-              }),
-          ChangeNotifierProvider(create: (_) => BlockedProvider()),
-          ChangeNotifierProvider(create: (_) => ThemeProvider()..setTheme(isDarkMode)),
-          ChangeNotifierProvider(create: (context) => ConnectivityProvider(context.read<ThemeProvider>())),
-        ],
-        child: const MyApp(),
-      ),
-    ),
-  );
+  runApp(const AraWebShell());
 }
 
-/// 스크롤 행동을 사용자 정의하기 위한 클래스
-class CustomScrollBehavior extends ScrollBehavior {
-  @override
-  Widget buildOverscrollIndicator(
-      BuildContext context, Widget child, ScrollableDetails details) {
-    return child;
-  }
-}
-
-/// 앱의 메인 위젯
-class MyApp extends StatefulWidget {
-  const MyApp({super.key});
-
-  @override
-  State<MyApp> createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
-  bool isLoading = false;
-
-  @override
-  void initState() {
-    super.initState();
-    // 자동 로그인을 위한 초기 설정
-    autoLoginByGetCookie(Provider.of<UserProvider>(context, listen: false));
-
-    // TODO: 아래 코드는 iOS 심사 통과를 위한 임시 방편. 익명 차단이 BE에서 구현되면 제거해야함 (2023.02.29)
-    // 앱이 시작될 때 shared preferences에서 차단한 글 목록 조회하기
-    BlockedProvider blockedProvider = context.read<BlockedProvider>();
-    blockedProvider.fetchBlockedAnonymousPostID().then((_) {
-      debugPrint("차단한 글 postid 목록: ${blockedProvider.blockedAnonymousPostIDs}");
-    });
-
-
-  }
-
-
-
-  /// 자동 로그인을 위한 메서드
-  /// secureStorage에서 쿠키를 가져와서 사용자 로그인 상태 확인
-  void autoLoginByGetCookie(UserProvider userProvider) async {
-    FlutterSecureStorage secureStorage = const FlutterSecureStorage();
-    var cookiesBySecureStorage = await secureStorage.read(key: 'cookie');
-
-    debugPrint("main.dart : $cookiesBySecureStorage.toString()");
-    if (cookiesBySecureStorage != null) {
-      setState(() {
-        isLoading = true;
-      });
-      debugPrint("main.dart s");
-      bool tf = await userProvider.apiMeUserInfo(
-          initCookieString: cookiesBySecureStorage);
-      debugPrint("main.dart : tf: $tf");
-      if (tf) {
-        userProvider.setHasData(true);
-        userProvider.setCookieToList(cookiesBySecureStorage);
-      }
-      setState(() {
-        isLoading = false;
-      });
-    }
-  }
+class AraWebShell extends StatelessWidget {
+  const AraWebShell({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final themeProvider = Provider.of<ThemeProvider>(context);
-
     return MaterialApp(
-        localizationsDelegates: context.localizationDelegates,
-        supportedLocales: context.supportedLocales,
-        locale: context.locale,
-        scaffoldMessengerKey: snackBarKey, //
-        theme: NewAraThemes.lightTheme,
-        darkTheme: NewAraThemes.darkTheme,
-        themeMode: themeProvider.themeMode,
-        // TODO: CustionScrollBehavior의 역할은?
-        builder: (context, child) {
-          final MediaQueryData data = MediaQuery.of(context);
-          return MediaQuery(
-            
-              // 시스템 폰트 사이즈에 영향을 받지 않도록 textScaleFactor 지정함
-            
-              data: data.copyWith(textScaler: const TextScaler.linear(1.0)),
-              child: ScrollConfiguration(
-                behavior: CustomScrollBehavior(),
-                child: child!,
-              ));
-        },
-        // 로그인 상태에 따라서 다른 홈페이지 표시
-        home: isLoading == true
-            ? const LoadingIndicator() // 로그인 중에는 로딩 인디케이터 표시
-            : context.watch<UserProvider>().hasData
-            ? (context
-            .watch<UserProvider>()
-            .naUser!
-            .agree_terms_of_service_at !=
-            null
-            ? const MainNavigationTabPage()
-            : const LoginPage())
-            : const LoginPage());
-  }
-
-  // 앱의 전반적인 테마 설정
-  ThemeData _setThemeData() {
-    return ThemeData(
-      appBarTheme:
-      const AppBarTheme(elevation: 0, backgroundColor: Colors.white, scrolledUnderElevation: 0.0),
-      fontFamily: 'Pretendard',
-      scaffoldBackgroundColor: Colors.white,
-      splashColor: Colors.transparent,
-      textSelectionTheme: const TextSelectionThemeData(
-        cursorColor: Colors.transparent,
+      debugShowCheckedModeBanner: false,
+      title: 'Ara',
+      theme: ThemeData(
+        fontFamily: 'Pretendard',
+        scaffoldBackgroundColor: Colors.white,
       ),
+      home: const _WebShell(),
     );
   }
 }
 
+class _WebShell extends StatefulWidget {
+  const _WebShell();
+
+  @override
+  State<_WebShell> createState() => _WebShellState();
+}
+
+class _WebShellState extends State<_WebShell> {
+  InAppWebViewController? _controller;
+  late final BridgeController _bridge;
+  late final PullToRefreshController _pullToRefresh;
+  bool _firstFrameDone = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _pullToRefresh = PullToRefreshController(
+      // iOS-style spinner — a brand-red ring matching the rest of the UI.
+      // The native side owns the *visual* of pull-to-refresh; the web
+      // listens for `refresh:requested` and answers with `refreshDone`.
+      settings: PullToRefreshSettings(
+        color: const Color(0xFFED3A3A),
+      ),
+      onRefresh: () async {
+        await _bridge.emit(BridgeEvent.refreshRequested);
+      },
+    );
+    _bridge = BridgeController(
+      getWebView: () => _controller,
+      getPullToRefresh: () => _pullToRefresh,
+    )..start();
+  }
+
+  @override
+  void dispose() {
+    _bridge.dispose();
+    super.dispose();
+  }
+
+  Uri get _entryUri => Uri.parse('$newAraDefaultUrl/web_view/Main');
+
+  InAppWebViewSettings get _settings => InAppWebViewSettings(
+        // Cookies persist in the platform cookie store; nothing else to do.
+        sharedCookiesEnabled: true,
+        thirdPartyCookiesEnabled: true,
+        javaScriptEnabled: true,
+        javaScriptCanOpenWindowsAutomatically: false,
+        mediaPlaybackRequiresUserGesture: false,
+        allowsInlineMediaPlayback: true,
+        useShouldOverrideUrlLoading: true,
+        transparentBackground: false,
+        // iOS: get rid of the "Done" accessory bar above the keyboard.
+        disableInputAccessoryView: true,
+        // Android keyboard handling: let the page's visualViewport drive layout.
+        useHybridComposition: true,
+        supportZoom: false,
+        // We control the user-agent so the web can detect "in app".
+        applicationNameForUserAgent: 'AraNative/1.0',
+        // iOS edge-swipe back gesture — Flutter's CupertinoPageRoute had
+        // it natively; without it the WebView feels "non-iOS".
+        allowsBackForwardNavigationGestures: true,
+      );
+
+  Future<NavigationActionPolicy?> _onShouldOverride(
+    InAppWebViewController controller,
+    NavigationAction action,
+  ) async {
+    final url = action.request.url;
+    if (url == null) return NavigationActionPolicy.ALLOW;
+
+    final scheme = url.scheme;
+    final isHttp = scheme == 'http' || scheme == 'https';
+    final isOurHost = url.host == _entryUri.host;
+
+    // 1. Tel / mail / market: hand off to the OS.
+    if (!isHttp) {
+      await _openExternal(url);
+      return NavigationActionPolicy.CANCEL;
+    }
+
+    // 2. Off-domain http(s) navigations open in the system browser. SSO is
+    //    in-flow (sparcs.org) so we whitelist a couple of hosts.
+    final whitelist = <String>{
+      _entryUri.host,
+      Uri.tryParse(sparcsSSODefaultUrl)?.host ?? '',
+      'sso.sparcs.org',
+      'sso.kaist.ac.kr',
+    }..removeWhere((s) => s.isEmpty);
+    if (!isOurHost && !whitelist.contains(url.host)) {
+      // Only redirect main-frame navigations the user explicitly triggered.
+      if (action.isForMainFrame == true && action.navigationType != NavigationType.OTHER) {
+        await _openExternal(url);
+        return NavigationActionPolicy.CANCEL;
+      }
+    }
+
+    return NavigationActionPolicy.ALLOW;
+  }
+
+  Future<void> _openExternal(Uri uri) async {
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } catch (e) {
+      debugPrint('openExternal failed: $e');
+    }
+  }
+
+  void _onWebViewCreated(InAppWebViewController controller) {
+    _controller = controller;
+    controller.addJavaScriptHandler(
+      handlerName: kJsHandlerName,
+      callback: (args) async {
+        await _bridge.handleMessage(args);
+      },
+    );
+  }
+
+  void _onLoadStop(InAppWebViewController controller, WebUri? url) {
+    if (!_firstFrameDone) {
+      _firstFrameDone = true;
+      FlutterNativeSplash.remove();
+    }
+  }
+
+  Future<bool> _onWillPop() async {
+    final wv = _controller;
+    if (wv == null) return true;
+    if (await wv.canGoBack()) {
+      await wv.goBack();
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.dark.copyWith(
+      statusBarColor: Colors.transparent,
+      statusBarIconBrightness: Brightness.dark,
+    ));
+
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop) return;
+        final shouldExit = await _onWillPop();
+        if (shouldExit && mounted) {
+          // Last screen in the stack: actually exit the app on Android.
+          if (Platform.isAndroid) {
+            await SystemNavigator.pop();
+          }
+        }
+      },
+      child: Scaffold(
+        backgroundColor: Colors.white,
+        // We let the WebView fill the whole screen; the web layout reads
+        // safe-area insets via the bridge handshake and applies them itself.
+        body: InAppWebView(
+          initialUrlRequest: URLRequest(url: WebUri.uri(_entryUri)),
+          initialSettings: _settings,
+          pullToRefreshController: _pullToRefresh,
+          onWebViewCreated: _onWebViewCreated,
+          shouldOverrideUrlLoading: _onShouldOverride,
+          onLoadStop: _onLoadStop,
+          onPermissionRequest: (controller, request) async {
+            return PermissionResponse(
+              resources: request.resources,
+              action: PermissionResponseAction.GRANT,
+            );
+          },
+          onConsoleMessage: (controller, msg) {
+            debugPrint('[webview] ${msg.messageLevel}: ${msg.message}');
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -30,6 +30,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -272,6 +304,70 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_inappwebview:
+    dependency: "direct main"
+    description:
+      name: flutter_inappwebview
+      sha256: "80092d13d3e29b6227e25b67973c67c7210bd5e35c4b747ca908e31eb71a46d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
+  flutter_inappwebview_android:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_android
+      sha256: "62557c15a5c2db5d195cb3892aab74fcaec266d7b86d59a6f0027abd672cddba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
+  flutter_inappwebview_internal_annotations:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_internal_annotations
+      sha256: "787171d43f8af67864740b6f04166c13190aa74a1468a1f1f1e9ee5b90c359cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  flutter_inappwebview_ios:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_ios
+      sha256: "5818cf9b26cf0cbb0f62ff50772217d41ea8d3d9cc00279c45f8aabaa1b4025d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_inappwebview_macos:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_macos
+      sha256: c1fbb86af1a3738e3541364d7d1866315ffb0468a1a77e34198c9be571287da1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_inappwebview_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_platform_interface
+      sha256: cf5323e194096b6ede7a1ca808c3e0a078e4b33cc3f6338977d75b4024ba2500
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0+1"
+  flutter_inappwebview_web:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_web
+      sha256: "55f89c83b0a0d3b7893306b3bb545ba4770a4df018204917148ebb42dc14a598"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_inappwebview_windows:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_windows
+      sha256: "8b4d3a46078a2cdc636c4a3d10d10f2a16882f6be607962dbfff8874d1642055"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -388,6 +484,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   html:
     dependency: "direct main"
     description:
@@ -628,6 +732,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,10 @@ dependencies:
   webview_flutter_wkwebview: "^3.10.2"
   flutter_dotenv: ^6.0.0
   connectivity_plus: ^7.0.0
+  # WebView shell + bridge stack
+  flutter_inappwebview: ^6.0.0
+  package_info_plus: ^8.0.0
+  app_links: ^6.3.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Introduce InAppWebView-based shell with a JS<->native bridge (bridge_controller, bridge_protocol) to host the Next.js web_view migration. Adds flutter_inappwebview, package_info_plus, app_links dependencies and refactors main.dart accordingly.

## Overview
<!-- 간단하게 이 PR이 무엇인지 설명해주세요. 예: 새로운 로그인 기능 추가 -->

## Changes
<!-- 이 PR로 인해 변경되는 사항을 나열해주세요. 예:
- 로그인 페이지 UI 업데이트
- 로그인 API 연동
- 로그인 에러 처리 추가
-->

## Implementaion Method
<!-- 변경사항을 구현한 방법에 대해 특별히 전달해야할 것이 있다면 설명해주세요. 예:
- React Hook을 사용하여 상태 관리
- JWT를 사용한 인증 처리
-->

## After Changes
<!-- 변경 사항을 확인 할 수 있는 방법을 알려주세요. 가능하다면, 변화를 보여주는 스크린샷 또는 동영상을 첨부해주세요. 예:
- 로그인 성공 시 홈페이지로 리다이렉트하는 동영상
-->

## Related Issues
<!-- 관련 버그 현상이나 관련 이슈 번호가 있다면 링크를 적어주거나 스크린샷을 첨부해주세요. 예: #123 -->

## Rollback Scenario
<!-- 해당 PR를 롤백하는 방법과 순서를 알려주세요. 예: 
1. revert commit
2. .env 파일 수정
-->

## TODO
<!-- 앞으로 해야하는 것이나, 논의가 필요한 부분 등을 적어주세요. 예:
- 로그인 관련 테스트 케이스 추가
- 다국어 지원 검토
-->
